### PR TITLE
[FEAT] 도메인 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,43 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.1'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.1'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.wss'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/wss/websoso/character/Character.java
+++ b/src/main/java/com/wss/websoso/character/Character.java
@@ -1,6 +1,10 @@
 package com.wss.websoso.character;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
@@ -8,12 +12,12 @@ import lombok.Getter;
 @Table(name = "character")
 public class Character {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long characterId;
-      private String characterTag;
-      private String characterImg;
-      private String characterComment;
-      private String characterDescription;
-      private String characterBadge;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long characterId;
+    private String characterTag;
+    private String characterImg;
+    private String characterComment;
+    private String characterDescription;
+    private String characterBadge;
 }

--- a/src/main/java/com/wss/websoso/character/Character.java
+++ b/src/main/java/com/wss/websoso/character/Character.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.character;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "character")
+public class Character {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long characterId;
+      private String characterTag;
+      private String characterImg;
+      private String characterComment;
+      private String characterDescription;
+      private String characterBadge;
+}

--- a/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
+++ b/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.wss.websoso.config;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+      @CreatedDate // 생성 시각, 현재 시각으로 초기화 해줌!
+      private String createdDate;
+
+      @PrePersist
+      public void onPrePersist() {
+            this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm"));
+      }
+}

--- a/src/main/java/com/wss/websoso/config/JpaAuditingConfig.java
+++ b/src/main/java/com/wss/websoso/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.wss.websoso.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/wss/websoso/config/ReadStatus.java
+++ b/src/main/java/com/wss/websoso/config/ReadStatus.java
@@ -1,0 +1,14 @@
+package com.wss.websoso.config;
+
+public enum ReadStatus {
+      finish("읽음"),
+      reading("읽는 중"),
+      drop("하차"),
+      wish("읽고 싶음");
+
+      private String status;
+
+      ReadStatus(String status) {
+            this.status = status;
+      }
+}

--- a/src/main/java/com/wss/websoso/config/ReadStatus.java
+++ b/src/main/java/com/wss/websoso/config/ReadStatus.java
@@ -1,14 +1,14 @@
 package com.wss.websoso.config;
 
 public enum ReadStatus {
-      finish("읽음"),
-      reading("읽는 중"),
-      drop("하차"),
-      wish("읽고 싶음");
+    FINISH("읽음"),
+    READING("읽는 중"),
+    DROP("하차"),
+    WISH("읽고 싶음");
 
-      private String status;
+    private String status;
 
-      ReadStatus(String status) {
-            this.status = status;
-      }
+    ReadStatus(String status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/wss/websoso/keyword/Keyword.java
+++ b/src/main/java/com/wss/websoso/keyword/Keyword.java
@@ -1,0 +1,15 @@
+package com.wss.websoso.keyword;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "keyword")
+public class Keyword {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long keywordId;
+      private String keywordName;
+}

--- a/src/main/java/com/wss/websoso/keyword/Keyword.java
+++ b/src/main/java/com/wss/websoso/keyword/Keyword.java
@@ -1,6 +1,10 @@
 package com.wss.websoso.keyword;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
@@ -8,8 +12,8 @@ import lombok.Getter;
 @Table(name = "keyword")
 public class Keyword {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long keywordId;
-      private String keywordName;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long keywordId;
+    private String keywordName;
 }

--- a/src/main/java/com/wss/websoso/memo/Memo.java
+++ b/src/main/java/com/wss/websoso/memo/Memo.java
@@ -2,7 +2,14 @@ package com.wss.websoso.memo;
 
 import com.wss.websoso.config.BaseTimeEntity;
 import com.wss.websoso.userNovel.UserNovel;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,18 +21,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memo extends BaseTimeEntity {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long memoId;
-      private String memoContent;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memoId;
+    private String memoContent;
 
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "user_novel_id")
-      private UserNovel userNovel;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_novel_id")
+    private UserNovel userNovel;
 
-      @Builder
-      private Memo(String memoContent, UserNovel userNovel) {
-            this.memoContent = memoContent;
-            this.userNovel = userNovel;
-      }
+    @Builder
+    private Memo(String memoContent, UserNovel userNovel) {
+        this.memoContent = memoContent;
+        this.userNovel = userNovel;
+    }
 }

--- a/src/main/java/com/wss/websoso/memo/Memo.java
+++ b/src/main/java/com/wss/websoso/memo/Memo.java
@@ -1,0 +1,31 @@
+package com.wss.websoso.memo;
+
+import com.wss.websoso.config.BaseTimeEntity;
+import com.wss.websoso.userNovel.UserNovel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "memo")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo extends BaseTimeEntity {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long memoId;
+      private String memoContent;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "user_novel_id")
+      private UserNovel userNovel;
+
+      @Builder
+      private Memo(String memoContent, UserNovel userNovel) {
+            this.memoContent = memoContent;
+            this.userNovel = userNovel;
+      }
+}

--- a/src/main/java/com/wss/websoso/novel/Novel.java
+++ b/src/main/java/com/wss/websoso/novel/Novel.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.novel;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "novel")
+public class Novel {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long novelId;
+      private String novelTitle;
+      private String novelAuthor;
+      private String novelGenre;
+      private String novelImg;
+      private String novelDescription;
+}

--- a/src/main/java/com/wss/websoso/novel/Novel.java
+++ b/src/main/java/com/wss/websoso/novel/Novel.java
@@ -1,6 +1,10 @@
 package com.wss.websoso.novel;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
@@ -8,12 +12,12 @@ import lombok.Getter;
 @Table(name = "novel")
 public class Novel {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long novelId;
-      private String novelTitle;
-      private String novelAuthor;
-      private String novelGenre;
-      private String novelImg;
-      private String novelDescription;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long novelId;
+    private String novelTitle;
+    private String novelAuthor;
+    private String novelGenre;
+    private String novelImg;
+    private String novelDescription;
 }

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -1,0 +1,44 @@
+package com.wss.websoso.platform;
+
+import com.wss.websoso.novel.Novel;
+import com.wss.websoso.userNovel.UserNovel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "platform")
+public class Platform {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long platformId;
+      private String platformName;
+      private String platformUrl;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "novel_id")
+      private Novel novel;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "user_novel_id")
+      private UserNovel userNovel;
+
+      @Builder
+      public Platform(String platformName, String platformUrl, Novel novel) {
+            this.platformName = platformName;
+            this.platformUrl = platformUrl;
+            this.novel = novel;
+      }
+
+      @Builder
+      public Platform(String platformName, String platformUrl, UserNovel userNovel) {
+            this.platformName = platformName;
+            this.platformUrl = platformUrl;
+            this.userNovel = userNovel;
+      }
+}

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -2,7 +2,14 @@ package com.wss.websoso.platform;
 
 import com.wss.websoso.novel.Novel;
 import com.wss.websoso.userNovel.UserNovel;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,31 +21,31 @@ import lombok.NoArgsConstructor;
 @Table(name = "platform")
 public class Platform {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long platformId;
-      private String platformName;
-      private String platformUrl;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long platformId;
+    private String platformName;
+    private String platformUrl;
 
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "novel_id")
-      private Novel novel;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id")
+    private Novel novel;
 
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "user_novel_id")
-      private UserNovel userNovel;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_novel_id")
+    private UserNovel userNovel;
 
-      @Builder
-      public Platform(String platformName, String platformUrl, Novel novel) {
-            this.platformName = platformName;
-            this.platformUrl = platformUrl;
-            this.novel = novel;
-      }
+    @Builder
+    public Platform(String platformName, String platformUrl, Novel novel) {
+        this.platformName = platformName;
+        this.platformUrl = platformUrl;
+        this.novel = novel;
+    }
 
-      @Builder
-      public Platform(String platformName, String platformUrl, UserNovel userNovel) {
-            this.platformName = platformName;
-            this.platformUrl = platformUrl;
-            this.userNovel = userNovel;
-      }
+    @Builder
+    public Platform(String platformName, String platformUrl, UserNovel userNovel) {
+        this.platformName = platformName;
+        this.platformUrl = platformUrl;
+        this.userNovel = userNovel;
+    }
 }

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -1,0 +1,15 @@
+package com.wss.websoso.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "user")
+public class User {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long userId;
+      private String userNickname;
+}

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -1,6 +1,10 @@
 package com.wss.websoso.user;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
@@ -8,8 +12,8 @@ import lombok.Getter;
 @Table(name = "user")
 public class User {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long userId;
-      private String userNickname;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+    private String userNickname;
 }

--- a/src/main/java/com/wss/websoso/userCharacter/UserCharacter.java
+++ b/src/main/java/com/wss/websoso/userCharacter/UserCharacter.java
@@ -1,0 +1,32 @@
+package com.wss.websoso.userCharacter;
+
+import com.wss.websoso.character.Character;
+import com.wss.websoso.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_character")
+public class UserCharacter {
+
+      @Id
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "user_id")
+      private User user;
+
+      @Id
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "character_id")
+      private Character character;
+
+      @Builder
+      public UserCharacter(User user, Character character) {
+            this.user = user;
+            this.character = character;
+      }
+}

--- a/src/main/java/com/wss/websoso/userCharacter/UserCharacter.java
+++ b/src/main/java/com/wss/websoso/userCharacter/UserCharacter.java
@@ -2,7 +2,14 @@ package com.wss.websoso.userCharacter;
 
 import com.wss.websoso.character.Character;
 import com.wss.websoso.user.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,19 +21,21 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_character")
 public class UserCharacter {
 
-      @Id
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "user_id")
-      private User user;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long UserCharacterId;
 
-      @Id
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "character_id")
-      private Character character;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-      @Builder
-      public UserCharacter(User user, Character character) {
-            this.user = user;
-            this.character = character;
-      }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id")
+    private Character character;
+
+    @Builder
+    public UserCharacter(User user, Character character) {
+        this.user = user;
+        this.character = character;
+    }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -2,7 +2,14 @@ package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.user.User;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,34 +21,34 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_novel")
 public class UserNovel {
 
-      @Id
-      @GeneratedValue(strategy = GenerationType.IDENTITY)
-      private Long userNovelId;
-      private String userNovelTitle;
-      private String userNovelAuthor;
-      private String userNovelGenre;
-      private String userNovelImg;
-      private String userNovelDescription;
-      private float userNovelRating;
-      private ReadStatus userNovelReadStatus;
-      private String userNovelReadStartDate;
-      private String userNovelReadEndDate;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userNovelId;
+    private String userNovelTitle;
+    private String userNovelAuthor;
+    private String userNovelGenre;
+    private String userNovelImg;
+    private String userNovelDescription;
+    private float userNovelRating;
+    private ReadStatus userNovelReadStatus;
+    private String userNovelReadStartDate;
+    private String userNovelReadEndDate;
 
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "user_id")
-      private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-      @Builder
-      public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
-            this.userNovelTitle = userNovelTitle;
-            this.userNovelAuthor = userNovelAuthor;
-            this.userNovelGenre = userNovelGenre;
-            this.userNovelImg = userNovelImg;
-            this.userNovelDescription = userNovelDescription;
-            this.userNovelRating = userNovelRating;
-            this.userNovelReadStatus = userNovelReadStatus;
-            this.userNovelReadStartDate = userNovelReadStartDate;
-            this.userNovelReadEndDate = userNovelReadEndDate;
-            this.user = user;
-      }
+    @Builder
+    public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+        this.userNovelTitle = userNovelTitle;
+        this.userNovelAuthor = userNovelAuthor;
+        this.userNovelGenre = userNovelGenre;
+        this.userNovelImg = userNovelImg;
+        this.userNovelDescription = userNovelDescription;
+        this.userNovelRating = userNovelRating;
+        this.userNovelReadStatus = userNovelReadStatus;
+        this.userNovelReadStartDate = userNovelReadStartDate;
+        this.userNovelReadEndDate = userNovelReadEndDate;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,0 +1,47 @@
+package com.wss.websoso.userNovel;
+
+import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_novel")
+public class UserNovel {
+
+      @Id
+      @GeneratedValue(strategy = GenerationType.IDENTITY)
+      private Long userNovelId;
+      private String userNovelTitle;
+      private String userNovelAuthor;
+      private String userNovelGenre;
+      private String userNovelImg;
+      private String userNovelDescription;
+      private float userNovelRating;
+      private ReadStatus userNovelReadStatus;
+      private String userNovelReadStartDate;
+      private String userNovelReadEndDate;
+
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "user_id")
+      private User user;
+
+      @Builder
+      public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+            this.userNovelTitle = userNovelTitle;
+            this.userNovelAuthor = userNovelAuthor;
+            this.userNovelGenre = userNovelGenre;
+            this.userNovelImg = userNovelImg;
+            this.userNovelDescription = userNovelDescription;
+            this.userNovelRating = userNovelRating;
+            this.userNovelReadStatus = userNovelReadStatus;
+            this.userNovelReadStartDate = userNovelReadStartDate;
+            this.userNovelReadEndDate = userNovelReadEndDate;
+            this.user = user;
+      }
+}

--- a/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeyword.java
+++ b/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeyword.java
@@ -1,0 +1,32 @@
+package com.wss.websoso.userNovelKeyword;
+
+import com.wss.websoso.keyword.Keyword;
+import com.wss.websoso.userNovel.UserNovel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_novel_keyword")
+public class UserNovelKeyword {
+
+      @Id
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "user_novel_id")
+      private UserNovel userNovel;
+
+      @Id
+      @ManyToOne(fetch = FetchType.LAZY)
+      @JoinColumn(name = "keyword_id")
+      private Keyword keyword;
+
+      @Builder
+      public UserNovelKeyword(UserNovel userNovel, Keyword keyword) {
+            this.userNovel = userNovel;
+            this.keyword = keyword;
+      }
+}

--- a/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeyword.java
+++ b/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeyword.java
@@ -2,7 +2,14 @@ package com.wss.websoso.userNovelKeyword;
 
 import com.wss.websoso.keyword.Keyword;
 import com.wss.websoso.userNovel.UserNovel;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,19 +21,21 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_novel_keyword")
 public class UserNovelKeyword {
 
-      @Id
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "user_novel_id")
-      private UserNovel userNovel;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long UserNovelKeywordId;
 
-      @Id
-      @ManyToOne(fetch = FetchType.LAZY)
-      @JoinColumn(name = "keyword_id")
-      private Keyword keyword;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_novel_id")
+    private UserNovel userNovel;
 
-      @Builder
-      public UserNovelKeyword(UserNovel userNovel, Keyword keyword) {
-            this.userNovel = userNovel;
-            this.keyword = keyword;
-      }
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id")
+    private Keyword keyword;
+
+    @Builder
+    public UserNovelKeyword(UserNovel userNovel, Keyword keyword) {
+        this.userNovel = userNovel;
+        this.keyword = keyword;
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#1 -> dev
- close #1 

## Key Changes
<!-- 최대한 자세히 -->
프로젝트에 사용될 모든 도메인을 구현했습니다.
폴더 구조는 도메인형을 따랐고, 공통으로 사용되는 엔티티는 `config` 패키지 내에 구현했습니다.
유저의 **읽기 상태**를 나타내는 값은 _enum_ 클래스로 구현했습니다.
메모의 생성 일시는 `BaseTimeEntity` 객체를 이용해, _insert_ 가 일어난 일시를 저장하도록 구현했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
수정사항이 있다면 말해주세요! 바로 반영하겠습니다!!

`UserNovelKeyword` 도메인에서 애매한 점이 있는데요!
`user_novel_keyword` 테이블에 기본키를 두 개로 구현했는데, 요 방법이 올바른 방법인지 잘 모르겠습니다...!
복합키를 사용하기 위해서는 `@IdClass`, `@EmbeddedId` 와 같은 어노테이션을 써야 하는 것 같기도 하고, 고유 id를 부여해 기본키로 사용하는 방법도 있을 것 같아요.
여러분의 생각은 어떠신가요!

```java
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(name = "user_novel_keyword")
public class UserNovelKeyword {

      @Id
      @ManyToOne(fetch = FetchType.LAZY)
      @JoinColumn(name = "user_novel_id")
      private UserNovel userNovel;

      @Id
      @ManyToOne(fetch = FetchType.LAZY)
      @JoinColumn(name = "keyword_id")
      private Keyword keyword;

      @Builder
      public UserNovelKeyword(UserNovel userNovel, Keyword keyword) {
            this.userNovel = userNovel;
            this.keyword = keyword;
      }
}
``` 

## References
<!-- 참고한 자료-->
X