### PR TITLE
[FEAT] 키워드 목록 조회 API 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/keyword/KeywordController.java
+++ b/src/main/java/com/wss/websoso/keyword/KeywordController.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.keyword;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @GetMapping("/keywords")
+    public List<Keyword> getKeywords() {
+        return keywordService.getKeywords();
+    }
+}

--- a/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
+++ b/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.keyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+}

--- a/src/main/java/com/wss/websoso/keyword/KeywordService.java
+++ b/src/main/java/com/wss/websoso/keyword/KeywordService.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.keyword;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+
+    public List<Keyword> getKeywords() {
+        return keywordRepository.findAll();
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#7 -> dev
- close #7

## Key Changes
<!-- 최대한 자세히 -->
키워드 목록 조회 API는 DB에 저장된 키워드를 모두 조회하여 반환하도록 구현했습니다.
반환값은 List<Keyword> 이며, Request Body에 데이터가 담깁니다.
- 예시
```
[
    {
        "keywordId": 1,
        "keywordName": "1번키워드"
    },
    {
        "keywordId": 2,
        "keywordName": "2번키워드"
    },
    {
        "keywordId": 3,
        "keywordName": "3번키워드"
    }
]
``` 
인증 인가만 수행하고 사용자 정보를 따로 추출하여 사용하지 않기 때문에 키워드 목록 조회 API는 파라미터를 아무것도 받지 않게 구현했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X
## References
<!-- 참고한 자료-->
X
