### PR TITLE
[FEAT] 작품 검색 API 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,0 +1,29 @@
+package com.wss.websoso.novel;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+
+    /*
+    word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
+    word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
+     */
+    @GetMapping
+    public List<Novel> getNovelsByWord(
+            @RequestParam Long lastNovelId,
+            @RequestParam int size,
+            @RequestParam String word) {
+        return novelService.getNovelsByWord(lastNovelId, size, word);
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelRepository.java
+++ b/src/main/java/com/wss/websoso/novel/NovelRepository.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NovelRepository extends JpaRepository<Novel, Long> {
-
-    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND n.novelTitle LIKE %?2% ORDER BY n.novelId DESC")
+    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND Function('replace', n.novelTitle, ' ', '') LIKE %?2% ORDER BY n.novelId DESC")
     Slice<Novel> findByIdLessThanOrderByIdDesc(Long lastNovelId, PageRequest pageRequest, String word);
 }

--- a/src/main/java/com/wss/websoso/novel/NovelRepository.java
+++ b/src/main/java/com/wss/websoso/novel/NovelRepository.java
@@ -1,0 +1,14 @@
+package com.wss.websoso.novel;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+
+    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND n.novelTitle LIKE %?2% ORDER BY n.novelId DESC")
+    Slice<Novel> findByIdLessThanOrderByIdDesc(Long lastNovelId, PageRequest pageRequest, String word);
+}

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -11,12 +11,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NovelService {
 
+    public static final int DEFAULT_PAGE_NUMBER = 0;
     private final NovelRepository novelRepository;
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
-        PageRequest pageRequest = PageRequest.of(0, size);
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
         Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
-        List<Novel> entityList = entitySlice.getContent();
-        return entityList;
+        return entitySlice.getContent();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -16,7 +16,7 @@ public class NovelService {
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word.replaceAll(" ", ""));
         return entitySlice.getContent();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,0 +1,22 @@
+package com.wss.websoso.novel;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    private final NovelRepository novelRepository;
+
+    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+        PageRequest pageRequest = PageRequest.of(0, size);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        List<Novel> entityList = entitySlice.getContent();
+        return entityList;
+    }
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#9 -> dev
- close #9

## Key Changes
<!-- 최대한 자세히 -->
유저가 검색어를 입력해, 해당 검색어가 포함된 웹소설 작품 리스트를 반환하는 API를 구현했습니다.
프론트단의 무한스크롤 구현을 위해, 파라미터로 총 3가지 값을 받습니다.
- 직전 호출 마지막 작품의 ID - lastNovelId
- 한 번 호출로 가져올 데이터 수 - size
- 해당 워드를 포함한 작품을 조회하기 위한 검색어 - word

직전 호출 마지막 작품의 ID를 받는 이유는 무한스크롤을 **No-offset 방식**으로 구현했기 때문입니다.
#### No-offset 방식의 동작 흐름은 아래와 같습니다.
1. 첫 호출 시 마지막 작품이 없기 때문에 프론트에서 **lastNovelId를 최대한 큰 수로 지정**
2. lastNovelId 보다 **Id값이 작은** 작품들 중 **size개**만큼 **ID(내림차순)순**으로 데이터를 반환
3. 프론트에서 데이터를 받은 뒤 마지막 데이터 ID를 알아내어 다시 호출
   - API 파라미터의 **lastNovelId를 마지막 데이터의 ID로 지정** (size, word는 동일)
4. lastNovelId 보다 Id값이 작은 작품들 중 size개만큼 ID(내림차순)순으로 데이터를 반환
5. 만약 더 이상 불러올 데이터가 없다면 **빈 리스트를 반환**

`NovelRepository` 코드는 해당 설명을 참고해주세요!
```java
// lastNovelId보다 작은 novelId를 가지며, 제목에 특정 단어(공백 무시)가 포함된 책들을 내림차순으로 정렬하여 가져온다.
// PageRequest 객체는 service단에서 size만큼 불러올 데이터의 개수를 지정해놓은 것
@Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND Function('replace', n.novelTitle, ' ', '') LIKE %?2% ORDER BY n.novelId DESC")
Slice<Novel> findByIdLessThanOrderByIdDesc(Long lastNovelId, PageRequest pageRequest, String word);
``` 

**추가 변경사항(1/5)**
기능 명세의 변경에 따라, 
검색을 수행할 때 사용자가 입력한 검색어와 DB내 웹소설 제목은 **모두 공백을 무시하고 조회되도록** 추가 구현을 했습니다!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
무한스크롤 API 구현은 처음이라 잘 구현을 한 건지 모르겠네요..!!
부족한 점이나 개선할 점이 있다면 말씀해주세요!!
바로 반영하도록 하겠습니다 :)

## References
<!-- 참고한 자료-->
https://kbwplace.tistory.com/178