### PR TITLE
[FEAT] 서재 작품 등록 API(GET) 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/keyword/Keyword.java
+++ b/src/main/java/com/wss/websoso/keyword/Keyword.java
@@ -1,11 +1,16 @@
 package com.wss.websoso.keyword;
 
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,4 +21,7 @@ public class Keyword {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long keywordId;
     private String keywordName;
+
+    @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL)
+    private List<UserNovelKeyword> userNovelKeywords;
 }

--- a/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
+++ b/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
@@ -3,6 +3,9 @@ package com.wss.websoso.keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    Optional<Keyword> findByKeywordName(String keywordName);
 }

--- a/src/main/java/com/wss/websoso/novel/Novel.java
+++ b/src/main/java/com/wss/websoso/novel/Novel.java
@@ -1,11 +1,18 @@
 package com.wss.websoso.novel;
 
+import com.wss.websoso.platform.Platform;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,4 +27,7 @@ public class Novel {
     private String novelGenre;
     private String novelImg;
     private String novelDescription;
+
+    @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Platform> platforms = new ArrayList<>();
 }

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -34,6 +34,11 @@ public class NovelController {
         return novelService.getNovelsByWord(lastNovelId, size, word);
     }
 
+    @GetMapping("{novelId}")
+    public ResponseEntity getNovelByNovelId(@PathVariable Long novelId, Principal principal) {
+        return novelService.getNovelByNovelId(novelId, Long.valueOf(principal.getName()));
+    }
+
     @PostMapping("{novelId}")
     public ResponseEntity<Void> createUserNovel(
             @PathVariable Long novelId,

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,0 +1,55 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.userNovel.UserNovelCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+
+    /*
+    word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
+    word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
+     */
+    @GetMapping
+    public List<Novel> getNovelsByWord(
+            @RequestParam Long lastNovelId,
+            @RequestParam int size,
+            @RequestParam String word) {
+        return novelService.getNovelsByWord(lastNovelId, size, word);
+    }
+
+    @GetMapping("{novelId}")
+    public NovelGetResponse getNovelByNovelId(@PathVariable Long novelId) {
+        return novelService.getNovelByNovelId(novelId);
+    }
+
+    @PostMapping("{novelId}")
+    public ResponseEntity<Void> createUserNovel(
+            @PathVariable Long novelId,
+            @RequestBody UserNovelCreateRequest userNovelCreateRequest,
+            Principal principal) {
+        URI location = URI.create("/userNovels/" + novelService.createUserNovel(
+                novelId,
+                Long.valueOf(principal.getName()),
+                userNovelCreateRequest)
+        );
+
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,0 +1,29 @@
+package com.wss.websoso.novel;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+
+    /*
+    word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
+    word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
+     */
+    @GetMapping
+    public List<Novel> getNovelsByWord(
+            @RequestParam Long lastNovelId,
+            @RequestParam int size,
+            @RequestParam String word) {
+        return novelService.getNovelsByWord(lastNovelId, size, word);
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,0 +1,38 @@
+package com.wss.websoso.novel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+    private final NovelRepository novelRepository;
+
+    /*
+    word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
+    word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
+     */
+    @GetMapping
+    public List<Novel> getNovelsByWord(
+            @RequestParam Long lastNovelId,
+            @RequestParam int size,
+            @RequestParam String word) {
+        return novelService.getNovelsByWord(lastNovelId, size, word);
+    }
+
+    @GetMapping("{novelId}")
+    public NovelGetResponse getNovelByNovelId(@PathVariable Long novelId) {
+        return novelService.getNovelByNovelId(novelId);
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/NovelGetResponse.java
@@ -1,0 +1,16 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.platform.PlatformGetResponse;
+
+import java.util.List;
+
+public record NovelGetResponse(
+        Long novelId,
+        String novelTitle,
+        String novelAuthor,
+        String novelGenre,
+        String novelImg,
+        String novelDescription,
+        List<PlatformGetResponse> platforms
+) {
+}

--- a/src/main/java/com/wss/websoso/novel/NovelRepository.java
+++ b/src/main/java/com/wss/websoso/novel/NovelRepository.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NovelRepository extends JpaRepository<Novel, Long> {
-
-    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND n.novelTitle LIKE %?2% ORDER BY n.novelId DESC")
+    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND Function('replace', n.novelTitle, ' ', '') LIKE %?2% ORDER BY n.novelId DESC")
     Slice<Novel> findByIdLessThanOrderByIdDesc(Long lastNovelId, PageRequest pageRequest, String word);
 }

--- a/src/main/java/com/wss/websoso/novel/NovelRepository.java
+++ b/src/main/java/com/wss/websoso/novel/NovelRepository.java
@@ -1,0 +1,14 @@
+package com.wss.websoso.novel;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+
+    @Query(value = "SELECT n FROM Novel n WHERE n.novelId < ?1 AND n.novelTitle LIKE %?2% ORDER BY n.novelId DESC")
+    Slice<Novel> findByIdLessThanOrderByIdDesc(Long lastNovelId, PageRequest pageRequest, String word);
+}

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -87,7 +87,7 @@ public class NovelService {
                                 .platformName(platform.getPlatformName())
                                 .platformUrl(platform.getPlatformUrl())
                                 .userNovel(userNovel)
-                                .builderWithUserNovel();
+                                .buildWithUserNovel();
 
                         platformRepository.save(newPlatform);
                     });

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -11,12 +11,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NovelService {
 
+    public static final int DEFAULT_PAGE_NUMBER = 0;
     private final NovelRepository novelRepository;
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
-        PageRequest pageRequest = PageRequest.of(0, size);
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
         Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
-        List<Novel> entityList = entitySlice.getContent();
-        return entityList;
+        return entitySlice.getContent();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -16,7 +16,7 @@ public class NovelService {
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word.replaceAll(" ", ""));
         return entitySlice.getContent();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,0 +1,22 @@
+package com.wss.websoso.novel;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    private final NovelRepository novelRepository;
+
+    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+        PageRequest pageRequest = PageRequest.of(0, size);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        List<Novel> entityList = entitySlice.getContent();
+        return entityList;
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -4,17 +4,20 @@ import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.keyword.Keyword;
 import com.wss.websoso.keyword.KeywordRepository;
 import com.wss.websoso.platform.Platform;
+import com.wss.websoso.platform.PlatformGetResponse;
 import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelCreateRequest;
+import com.wss.websoso.userNovel.UserNovelGetResponse;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import com.wss.websoso.userNovelKeyword.UserNovelKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -37,7 +40,57 @@ public class NovelService {
         Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
         return entitySlice.getContent();
     }
-  
+
+    public ResponseEntity<?> getNovelByNovelId(Long novelId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        try {
+            UserNovel userNovel = userNovelRepository.findByUserAndNovelId(user, novelId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당하는 등록된 작품이 없습니다."));
+
+            return ResponseEntity.ok(new UserNovelGetResponse(
+                    userNovel.getUserNovelId(),
+                    userNovel.getUserNovelTitle(),
+                    userNovel.getUserNovelAuthor(),
+                    userNovel.getUserNovelGenre(),
+                    userNovel.getUserNovelImg(),
+                    userNovel.getUserNovelDescription(),
+                    userNovel.getUserNovelRating(),
+                    userNovel.getUserNovelReadStatus(),
+                    userNovel.getUserNovelReadStartDate(),
+                    userNovel.getUserNovelReadEndDate(),
+                    userNovel.getUserNovelKeywords().stream()
+                            .map(userNovelKeyword -> userNovelKeyword.getKeyword().getKeywordName())
+                            .toList(),
+                    userNovel.getPlatforms().stream()
+                            .map(platform -> new PlatformGetResponse(
+                                    platform.getPlatformName(),
+                                    platform.getPlatformUrl()
+                            ))
+                            .toList()
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.ok(new NovelGetResponse(
+                    novel.getNovelId(),
+                    novel.getNovelTitle(),
+                    novel.getNovelAuthor(),
+                    novel.getNovelGenre(),
+                    novel.getNovelImg(),
+                    novel.getNovelDescription(),
+                    novel.getPlatforms().stream()
+                            .map(platform -> new PlatformGetResponse(
+                                    platform.getPlatformName(),
+                                    platform.getPlatformUrl()
+                            ))
+                            .toList()
+            ));
+        }
+    }
+
     public Long createUserNovel(Long novelId, Long userId, UserNovelCreateRequest userNovelCreateRequest) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,0 +1,43 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.platform.PlatformGetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    public static final int DEFAULT_PAGE_NUMBER = 0;
+    private final NovelRepository novelRepository;
+
+    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        return entitySlice.getContent();
+    }
+
+    public NovelGetResponse getNovelByNovelId(Long novelId) {
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        return new NovelGetResponse(
+                novel.getNovelId(),
+                novel.getNovelTitle(),
+                novel.getNovelAuthor(),
+                novel.getNovelGenre(),
+                novel.getNovelImg(),
+                novel.getNovelDescription(),
+                novel.getPlatforms().stream()
+                        .map(platform -> new PlatformGetResponse(
+                                platform.getPlatformName(),
+                                platform.getPlatformUrl()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -66,6 +66,7 @@ public class NovelService {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
 
         UserNovel userNovel = UserNovel.builder()
+                .novelId(novelId)
                 .userNovelTitle(novel.getNovelTitle())
                 .userNovelAuthor(novel.getNovelAuthor())
                 .userNovelGenre(novel.getNovelGenre())

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -3,6 +3,8 @@ package com.wss.websoso.novel;
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.keyword.Keyword;
 import com.wss.websoso.keyword.KeywordRepository;
+import com.wss.websoso.platform.Platform;
+import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
@@ -28,6 +30,7 @@ public class NovelService {
     private final UserNovelRepository userNovelRepository;
     private final UserNovelKeywordRepository userNovelKeywordRepository;
     private final KeywordRepository keywordRepository;
+    private final PlatformRepository platformRepository;
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
@@ -77,10 +80,23 @@ public class NovelService {
 
         userNovelRepository.save(userNovel);
 
-        if (userNovelCreateRequest.keywordIds() != null) {
-            userNovelCreateRequest.keywordIds().stream()
-                    .map(keywordId -> {
-                        Optional<Keyword> optionalKeyword = keywordRepository.findById(keywordId);
+        if (novel.getPlatforms() != null) {
+            novel.getPlatforms().stream()
+                    .forEach(platform -> {
+                        Platform newPlatform = Platform.builderWithUserNovel()
+                                .platformName(platform.getPlatformName())
+                                .platformUrl(platform.getPlatformUrl())
+                                .userNovel(userNovel)
+                                .builderWithUserNovel();
+
+                        platformRepository.save(newPlatform);
+                    });
+        }
+
+        if (userNovelCreateRequest.keywordNames() != null) {
+            userNovelCreateRequest.keywordNames().stream()
+                    .map(keywordName -> {
+                        Optional<Keyword> optionalKeyword = keywordRepository.findByKeywordName(keywordName);
                         if (optionalKeyword.isEmpty()) {
                             throw new IllegalArgumentException("해당하는 키워드가 없습니다.");
                         }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -98,8 +98,4 @@ public class NovelService {
 
         return userNovel.getUserNovelId();
     }
-
-    public void deleteUserNovel(Long userNovelId) {
-        userNovelRepository.deleteById(userNovelId);
-    }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,0 +1,105 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.keyword.Keyword;
+import com.wss.websoso.keyword.KeywordRepository;
+import com.wss.websoso.user.User;
+import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userNovel.UserNovel;
+import com.wss.websoso.userNovel.UserNovelCreateRequest;
+import com.wss.websoso.userNovel.UserNovelRepository;
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import com.wss.websoso.userNovelKeyword.UserNovelKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    public static final int DEFAULT_PAGE_NUMBER = 0;
+    private final NovelRepository novelRepository;
+    private final UserRepository userRepository;
+    private final UserNovelRepository userNovelRepository;
+    private final UserNovelKeywordRepository userNovelKeywordRepository;
+    private final KeywordRepository keywordRepository;
+
+    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        return entitySlice.getContent();
+    }
+
+    public NovelGetResponse getNovelByNovelId(Long novelId) {
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        return new NovelGetResponse(
+                novel.getNovelId(),
+                novel.getNovelTitle(),
+                novel.getNovelAuthor(),
+                novel.getNovelGenre(),
+                novel.getNovelImg(),
+                novel.getNovelDescription(),
+                novel.getPlatforms().stream()
+                        .map(platform -> new PlatformGetResponse(
+                                platform.getPlatformName(),
+                                platform.getPlatformUrl()
+                        ))
+                        .toList()
+        );
+    }
+
+    public Long createUserNovel(Long novelId, Long userId, UserNovelCreateRequest userNovelCreateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        UserNovel userNovel = UserNovel.builder()
+                .userNovelTitle(novel.getNovelTitle())
+                .userNovelAuthor(novel.getNovelAuthor())
+                .userNovelGenre(novel.getNovelGenre())
+                .userNovelImg(novel.getNovelImg())
+                .userNovelDescription(novel.getNovelDescription())
+                .userNovelRating(userNovelCreateRequest.novelRating())
+                .userNovelReadStatus(ReadStatus.valueOf(userNovelCreateRequest.novelReadStatus()))
+                .userNovelReadStartDate(userNovelCreateRequest.novelReadStartDate())
+                .userNovelReadEndDate(userNovelCreateRequest.novelReadEndDate())
+                .user(user)
+                .build();
+
+        userNovelRepository.save(userNovel);
+
+        if (userNovelCreateRequest.keywordIds() != null) {
+            userNovelCreateRequest.keywordIds().stream()
+                    .map(keywordId -> {
+                        Optional<Keyword> optionalKeyword = keywordRepository.findById(keywordId);
+                        if (optionalKeyword.isEmpty()) {
+                            throw new IllegalArgumentException("해당하는 키워드가 없습니다.");
+                        }
+                        return optionalKeyword.get();
+                    })
+                    .forEach(keyword -> {
+                        UserNovelKeyword userNovelKeyword = UserNovelKeyword.builder()
+                                .userNovel(userNovel)
+                                .keyword(keyword)
+                                .build();
+
+                        userNovelKeywordRepository.save(userNovelKeyword);
+                    });
+        }
+
+        return userNovel.getUserNovelId();
+    }
+
+    public void deleteUserNovel(Long userNovelId) {
+        userNovelRepository.deleteById(userNovelId);
+    }
+}

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -42,7 +42,7 @@ public class Platform {
         this.novel = novel;
     }
 
-    @Builder
+    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "builderWithUserNovel")
     public Platform(String platformName, String platformUrl, UserNovel userNovel) {
         this.platformName = platformName;
         this.platformUrl = platformUrl;

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -42,7 +42,7 @@ public class Platform {
         this.novel = novel;
     }
 
-    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "builderWithUserNovel")
+    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "buildWithUserNovel")
     public Platform(String platformName, String platformUrl, UserNovel userNovel) {
         this.platformName = platformName;
         this.platformUrl = platformUrl;

--- a/src/main/java/com/wss/websoso/platform/PlatformGetResponse.java
+++ b/src/main/java/com/wss/websoso/platform/PlatformGetResponse.java
@@ -1,0 +1,7 @@
+package com.wss.websoso.platform;
+
+public record PlatformGetResponse(
+        String platformName,
+        String platformUrl
+) {
+}

--- a/src/main/java/com/wss/websoso/platform/PlatformRepository.java
+++ b/src/main/java/com/wss/websoso/platform/PlatformRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.platform;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlatformRepository extends JpaRepository<Platform, Long> {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -2,6 +2,8 @@ package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.user.User;
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,11 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,6 +42,9 @@ public class UserNovel {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
+    private List<UserNovelKeyword> userNovelKeywords;
 
     @Builder
     public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
 import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import jakarta.persistence.CascadeType;
@@ -18,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -45,6 +47,9 @@ public class UserNovel {
 
     @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
     private List<UserNovelKeyword> userNovelKeywords;
+
+    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Platform> platforms = new ArrayList<>();
 
     @Builder
     public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -45,7 +45,7 @@ public class UserNovel {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserNovelKeyword> userNovelKeywords;
 
     @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -31,6 +31,7 @@ public class UserNovel {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userNovelId;
+    private Long novelId;
     private String userNovelTitle;
     private String userNovelAuthor;
     private String userNovelGenre;
@@ -52,7 +53,8 @@ public class UserNovel {
     private List<Platform> platforms = new ArrayList<>();
 
     @Builder
-    public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+        this.novelId = novelId;
         this.userNovelTitle = userNovelTitle;
         this.userNovelAuthor = userNovelAuthor;
         this.userNovelGenre = userNovelGenre;

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
@@ -7,6 +7,6 @@ public record UserNovelCreateRequest(
         String novelReadStatus,
         String novelReadStartDate,
         String novelReadEndDate,
-        List<Long> keywordIds
+        List<String> keywordNames
 ) {
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
@@ -1,0 +1,12 @@
+package com.wss.websoso.userNovel;
+
+import java.util.List;
+
+public record UserNovelCreateRequest(
+        float novelRating,
+        String novelReadStatus,
+        String novelReadStartDate,
+        String novelReadEndDate,
+        List<Long> keywordIds
+) {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelGetResponse.java
@@ -1,0 +1,22 @@
+package com.wss.websoso.userNovel;
+
+import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.platform.PlatformGetResponse;
+
+import java.util.List;
+
+public record UserNovelGetResponse(
+        Long userNovelId,
+        String userNovelTitle,
+        String userNovelAuthor,
+        String userNovelGenre,
+        String userNovelImg,
+        String userNovelDescription,
+        float userNovelRating,
+        ReadStatus userNovelReadStatus,
+        String userNovelReadStartDate,
+        String userNovelReadEndDate,
+        List<String> keywords,
+        List<PlatformGetResponse> platforms
+) {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -1,8 +1,12 @@
 package com.wss.websoso.userNovel;
 
+import com.wss.websoso.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+    Optional<UserNovel> findByUserAndNovelId(User user, Long novelId);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.userNovel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+}

--- a/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeywordRepository.java
+++ b/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeywordRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.userNovelKeyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNovelKeywordRepository extends JpaRepository<UserNovelKeyword, Long> {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#13 -> dev
- close #13

## Key Changes
<!-- 최대한 자세히 -->
>`NovelRepository`가 없는 이유는 아직 병합이 되지 않았지만 #10 에서 구현을 한 뒤로 수정사항이 없기 때문입니다!
1. Novel 엔티티에서 {해당 NovelId를 FK로 가지고 있는 **Platform 리스트**}를 조회할 수 있도록 양방향 매핑을 설정했습니다.
```java
@OneToMany(mappedBy = "novel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
private List<Platform> platforms = new ArrayList<>();
```
- `cascade = CascadeType.ALL` 옵션을 주어 작품이 삭제되면 해당 작품의 플랫폼도 삭제되도록 설정

2. Response 형식을 아래와 같이 맞추기 위해 3가지 DTO(`NovelGetResponse`, `PlatformGetResponse`, `UserNovelGetResponse`)를 생성했습니다.

**(+ 1/7 추가)**
3. 작품 조회 시, 해당 작품이 이미 서재에 등록되어 있다면 UserNovel 정보를 반환하도록 기능을 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X