### PR TITLE
[FEAT] 서재 작품 등록 API(POST) 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/keyword/Keyword.java
+++ b/src/main/java/com/wss/websoso/keyword/Keyword.java
@@ -1,11 +1,16 @@
 package com.wss.websoso.keyword;
 
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,4 +21,7 @@ public class Keyword {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long keywordId;
     private String keywordName;
+
+    @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL)
+    private List<UserNovelKeyword> userNovelKeywords;
 }

--- a/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
+++ b/src/main/java/com/wss/websoso/keyword/KeywordRepository.java
@@ -3,6 +3,9 @@ package com.wss.websoso.keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    Optional<Keyword> findByKeywordName(String keywordName);
 }

--- a/src/main/java/com/wss/websoso/novel/Novel.java
+++ b/src/main/java/com/wss/websoso/novel/Novel.java
@@ -1,11 +1,18 @@
 package com.wss.websoso.novel;
 
+import com.wss.websoso.platform.Platform;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,4 +27,7 @@ public class Novel {
     private String novelGenre;
     private String novelImg;
     private String novelDescription;
+
+    @OneToMany(mappedBy = "novel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Platform> platforms = new ArrayList<>();
 }

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,0 +1,55 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.userNovel.UserNovelCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/novels")
+public class NovelController {
+
+    private final NovelService novelService;
+
+    /*
+    word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
+    word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
+     */
+    @GetMapping
+    public List<Novel> getNovelsByWord(
+            @RequestParam Long lastNovelId,
+            @RequestParam int size,
+            @RequestParam String word) {
+        return novelService.getNovelsByWord(lastNovelId, size, word);
+    }
+
+    @GetMapping("{novelId}")
+    public NovelGetResponse getNovelByNovelId(@PathVariable Long novelId) {
+        return novelService.getNovelByNovelId(novelId);
+    }
+
+    @PostMapping("{novelId}")
+    public ResponseEntity<Void> createUserNovel(
+            @PathVariable Long novelId,
+            @RequestBody UserNovelCreateRequest userNovelCreateRequest,
+            Principal principal) {
+        URI location = URI.create("/userNovels/" + novelService.createUserNovel(
+                novelId,
+                Long.valueOf(principal.getName()),
+                userNovelCreateRequest)
+        );
+
+        return ResponseEntity.created(location).build();
+    }
+}

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -87,7 +87,7 @@ public class NovelService {
                                 .platformName(platform.getPlatformName())
                                 .platformUrl(platform.getPlatformUrl())
                                 .userNovel(userNovel)
-                                .builderWithUserNovel();
+                                .buildWithUserNovel();
 
                         platformRepository.save(newPlatform);
                     });

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -66,6 +66,7 @@ public class NovelService {
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
 
         UserNovel userNovel = UserNovel.builder()
+                .novelId(novelId)
                 .userNovelTitle(novel.getNovelTitle())
                 .userNovelAuthor(novel.getNovelAuthor())
                 .userNovelGenre(novel.getNovelGenre())

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -3,6 +3,8 @@ package com.wss.websoso.novel;
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.keyword.Keyword;
 import com.wss.websoso.keyword.KeywordRepository;
+import com.wss.websoso.platform.Platform;
+import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
@@ -28,6 +30,7 @@ public class NovelService {
     private final UserNovelRepository userNovelRepository;
     private final UserNovelKeywordRepository userNovelKeywordRepository;
     private final KeywordRepository keywordRepository;
+    private final PlatformRepository platformRepository;
 
     public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
@@ -77,10 +80,23 @@ public class NovelService {
 
         userNovelRepository.save(userNovel);
 
-        if (userNovelCreateRequest.keywordIds() != null) {
-            userNovelCreateRequest.keywordIds().stream()
-                    .map(keywordId -> {
-                        Optional<Keyword> optionalKeyword = keywordRepository.findById(keywordId);
+        if (novel.getPlatforms() != null) {
+            novel.getPlatforms().stream()
+                    .forEach(platform -> {
+                        Platform newPlatform = Platform.builderWithUserNovel()
+                                .platformName(platform.getPlatformName())
+                                .platformUrl(platform.getPlatformUrl())
+                                .userNovel(userNovel)
+                                .builderWithUserNovel();
+
+                        platformRepository.save(newPlatform);
+                    });
+        }
+
+        if (userNovelCreateRequest.keywordNames() != null) {
+            userNovelCreateRequest.keywordNames().stream()
+                    .map(keywordName -> {
+                        Optional<Keyword> optionalKeyword = keywordRepository.findByKeywordName(keywordName);
                         if (optionalKeyword.isEmpty()) {
                             throw new IllegalArgumentException("해당하는 키워드가 없습니다.");
                         }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -98,8 +98,4 @@ public class NovelService {
 
         return userNovel.getUserNovelId();
     }
-
-    public void deleteUserNovel(Long userNovelId) {
-        userNovelRepository.deleteById(userNovelId);
-    }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,0 +1,105 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.keyword.Keyword;
+import com.wss.websoso.keyword.KeywordRepository;
+import com.wss.websoso.user.User;
+import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userNovel.UserNovel;
+import com.wss.websoso.userNovel.UserNovelCreateRequest;
+import com.wss.websoso.userNovel.UserNovelRepository;
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import com.wss.websoso.userNovelKeyword.UserNovelKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    public static final int DEFAULT_PAGE_NUMBER = 0;
+    private final NovelRepository novelRepository;
+    private final UserRepository userRepository;
+    private final UserNovelRepository userNovelRepository;
+    private final UserNovelKeywordRepository userNovelKeywordRepository;
+    private final KeywordRepository keywordRepository;
+
+    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
+        return entitySlice.getContent();
+    }
+
+    public NovelGetResponse getNovelByNovelId(Long novelId) {
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        return new NovelGetResponse(
+                novel.getNovelId(),
+                novel.getNovelTitle(),
+                novel.getNovelAuthor(),
+                novel.getNovelGenre(),
+                novel.getNovelImg(),
+                novel.getNovelDescription(),
+                novel.getPlatforms().stream()
+                        .map(platform -> new PlatformGetResponse(
+                                platform.getPlatformName(),
+                                platform.getPlatformUrl()
+                        ))
+                        .toList()
+        );
+    }
+
+    public Long createUserNovel(Long novelId, Long userId, UserNovelCreateRequest userNovelCreateRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Novel novel = novelRepository.findById(novelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
+
+        UserNovel userNovel = UserNovel.builder()
+                .userNovelTitle(novel.getNovelTitle())
+                .userNovelAuthor(novel.getNovelAuthor())
+                .userNovelGenre(novel.getNovelGenre())
+                .userNovelImg(novel.getNovelImg())
+                .userNovelDescription(novel.getNovelDescription())
+                .userNovelRating(userNovelCreateRequest.novelRating())
+                .userNovelReadStatus(ReadStatus.valueOf(userNovelCreateRequest.novelReadStatus()))
+                .userNovelReadStartDate(userNovelCreateRequest.novelReadStartDate())
+                .userNovelReadEndDate(userNovelCreateRequest.novelReadEndDate())
+                .user(user)
+                .build();
+
+        userNovelRepository.save(userNovel);
+
+        if (userNovelCreateRequest.keywordIds() != null) {
+            userNovelCreateRequest.keywordIds().stream()
+                    .map(keywordId -> {
+                        Optional<Keyword> optionalKeyword = keywordRepository.findById(keywordId);
+                        if (optionalKeyword.isEmpty()) {
+                            throw new IllegalArgumentException("해당하는 키워드가 없습니다.");
+                        }
+                        return optionalKeyword.get();
+                    })
+                    .forEach(keyword -> {
+                        UserNovelKeyword userNovelKeyword = UserNovelKeyword.builder()
+                                .userNovel(userNovel)
+                                .keyword(keyword)
+                                .build();
+
+                        userNovelKeywordRepository.save(userNovelKeyword);
+                    });
+        }
+
+        return userNovel.getUserNovelId();
+    }
+
+    public void deleteUserNovel(Long userNovelId) {
+        userNovelRepository.deleteById(userNovelId);
+    }
+}

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -42,7 +42,7 @@ public class Platform {
         this.novel = novel;
     }
 
-    @Builder
+    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "builderWithUserNovel")
     public Platform(String platformName, String platformUrl, UserNovel userNovel) {
         this.platformName = platformName;
         this.platformUrl = platformUrl;

--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -42,7 +42,7 @@ public class Platform {
         this.novel = novel;
     }
 
-    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "builderWithUserNovel")
+    @Builder(builderMethodName = "builderWithUserNovel", buildMethodName = "buildWithUserNovel")
     public Platform(String platformName, String platformUrl, UserNovel userNovel) {
         this.platformName = platformName;
         this.platformUrl = platformUrl;

--- a/src/main/java/com/wss/websoso/platform/PlatformRepository.java
+++ b/src/main/java/com/wss/websoso/platform/PlatformRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.platform;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlatformRepository extends JpaRepository<Platform, Long> {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -2,6 +2,8 @@ package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.user.User;
+import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,11 +11,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -37,6 +42,9 @@ public class UserNovel {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
+    private List<UserNovelKeyword> userNovelKeywords;
 
     @Builder
     public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
 import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import jakarta.persistence.CascadeType;
@@ -18,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -45,6 +47,9 @@ public class UserNovel {
 
     @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
     private List<UserNovelKeyword> userNovelKeywords;
+
+    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Platform> platforms = new ArrayList<>();
 
     @Builder
     public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -45,7 +45,7 @@ public class UserNovel {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "userNovel", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserNovelKeyword> userNovelKeywords;
 
     @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -31,6 +31,7 @@ public class UserNovel {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userNovelId;
+    private Long novelId;
     private String userNovelTitle;
     private String userNovelAuthor;
     private String userNovelGenre;
@@ -52,7 +53,8 @@ public class UserNovel {
     private List<Platform> platforms = new ArrayList<>();
 
     @Builder
-    public UserNovel(String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+        this.novelId = novelId;
         this.userNovelTitle = userNovelTitle;
         this.userNovelAuthor = userNovelAuthor;
         this.userNovelGenre = userNovelGenre;

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
@@ -7,6 +7,6 @@ public record UserNovelCreateRequest(
         String novelReadStatus,
         String novelReadStartDate,
         String novelReadEndDate,
-        List<Long> keywordIds
+        List<String> keywordNames
 ) {
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
@@ -1,0 +1,12 @@
+package com.wss.websoso.userNovel;
+
+import java.util.List;
+
+public record UserNovelCreateRequest(
+        float novelRating,
+        String novelReadStatus,
+        String novelReadStartDate,
+        String novelReadEndDate,
+        List<Long> keywordIds
+) {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.userNovel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+}

--- a/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeywordRepository.java
+++ b/src/main/java/com/wss/websoso/userNovelKeyword/UserNovelKeywordRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.userNovelKeyword;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNovelKeywordRepository extends JpaRepository<UserNovelKeyword, Long> {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#15 -> dev
- close #15

## Key Changes
<!-- 최대한 자세히 -->
1. 해당 API는 파라미터로 총 3가지 값(`novelId`, `UserNovelCreateRequest`, `Principal`)을 받아 호출됩니다.
Principal 객체를 받는 이유는 현재 로그인 한 유저의 정보를 알고 해당 유저 서재에 작품을 등록해야 하기 때문입니다.

2. 해당 API 호출 시 `UserNovel` 엔티티를 생성하기 때문에 응답 코드 `201 created`를 반환하도록 구현했습니다.
created 응답을 하기 위해서는 URI 값이 필요하여 컨트롤러단에서 생성하여 넣어주었습니다.

**+ 1/5 추가**
3. `Keyword`, `UserNovel` 둘 중 하나라도 삭제될 시 해당 엔티티와 연결된 `UserNovelKeyword`가 삭제되도록 구현했고, `Novel`, `UserNovel` 둘 중 하나라도 삭제될 시 해당 엔티티와 연결된 `Platform`이 삭제되도록 구현했습니다.
```java
// 예시 - Keyword 클래스 내
@OneToMany(mappedBy = "keyword", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
private List<UserNovelKeyword> userNovelKeywords;
// 예시 - Novel 클래스 내
@OneToMany(mappedBy = "novel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
private List<Platform> platforms = new ArrayList<>();
``` 

4. Request Body를 통해 {키워드 ID 리스트를 받던 부분}을 {키워드 이름 리스트를 받도록} 수정했습니다. 
API 명세서에 나와있는 대로 키워드 이름 리스트를 받아, UserNovel과 매핑하도록 재구현하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
직전에 Novel 엔티티 관련 API 제작했던 것이 아직 dev 브랜치에 반영되지 않아, 현재 이 pr 내의 커밋에도 적용이 되어 있지 않아요! 어느 부분이 추가 되었는지 알아보기가 어려워, 혼동되는 부분이 있다면 바로 말씀해주세요!!
NovelService내의 createUserNovel() 메서드를 중점으로 보시면 좋을 것 같습니다!

## References
<!-- 참고한 자료-->
X