### PR TITLE
[FIX] 작품 검색 API Response를 DTO를 통해 반환하도록 수정

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -27,7 +27,7 @@ public class NovelController {
     word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
      */
     @GetMapping
-    public List<Novel> getNovelsByWord(
+    public List<NovelGetResponse> getNovelsByWord(
             @RequestParam Long lastNovelId,
             @RequestParam int size,
             @RequestParam String word) {

--- a/src/main/java/com/wss/websoso/novel/NovelDetailGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/NovelDetailGetResponse.java
@@ -1,0 +1,16 @@
+package com.wss.websoso.novel;
+
+import com.wss.websoso.platform.PlatformGetResponse;
+
+import java.util.List;
+
+public record NovelDetailGetResponse(
+        Long novelId,
+        String novelTitle,
+        String novelAuthor,
+        String novelGenre,
+        String novelImg,
+        String novelDescription,
+        List<PlatformGetResponse> platforms
+) {
+}

--- a/src/main/java/com/wss/websoso/novel/NovelGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/NovelGetResponse.java
@@ -1,16 +1,10 @@
 package com.wss.websoso.novel;
 
-import com.wss.websoso.platform.PlatformGetResponse;
-
-import java.util.List;
-
 public record NovelGetResponse(
         Long novelId,
         String novelTitle,
         String novelAuthor,
         String novelGenre,
-        String novelImg,
-        String novelDescription,
-        List<PlatformGetResponse> platforms
+        String novelImg
 ) {
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -35,10 +35,18 @@ public class NovelService {
     private final KeywordRepository keywordRepository;
     private final PlatformRepository platformRepository;
 
-    public List<Novel> getNovelsByWord(Long lastNovelId, int size, String word) {
+    public List<NovelGetResponse> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
         Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
-        return entitySlice.getContent();
+        return entitySlice.getContent().stream()
+                .map(novel -> new NovelGetResponse(
+                        novel.getNovelId(),
+                        novel.getNovelTitle(),
+                        novel.getNovelAuthor(),
+                        novel.getNovelGenre(),
+                        novel.getNovelImg()
+                ))
+                .toList();
     }
 
     public ResponseEntity<?> getNovelByNovelId(Long novelId, Long userId) {
@@ -74,7 +82,7 @@ public class NovelService {
                             .toList()
             ));
         } catch (IllegalArgumentException e) {
-            return ResponseEntity.ok(new NovelGetResponse(
+            return ResponseEntity.ok(new NovelDetailGetResponse(
                     novel.getNovelId(),
                     novel.getNovelTitle(),
                     novel.getNovelAuthor(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#22 -> dev
- close #22

## Key Changes
<!-- 최대한 자세히 -->
기존에 Novel 엔티티 값을 그대로 반환했지만, 작품 검색 API Response에 novelDescription 값은 필요하지 않아, DTO를 통해 필요한 데이터만 반환하도록 기능을 수정했습니다.

기존에 사용하던 NovelGetResponse 클래스가 존재하여, 해당 클래스 이름을 NovelDetailGetResponse로 변경하고, NovelGetResponse 클래스를 사용했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X
## References
<!-- 참고한 자료-->
X