### PR TITLE
[FEAT] 서재 작품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/config/ReadStatus.java
+++ b/src/main/java/com/wss/websoso/config/ReadStatus.java
@@ -1,14 +1,17 @@
 package com.wss.websoso.config;
 
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ReadStatus {
-    FINISH("읽음"),
-    READING("읽는 중"),
-    DROP("하차"),
-    WISH("읽고 싶음");
+    FINISH("FINISH"),
+    READING("READING"),
+    DROP("DROP"),
+    WISH("WISH");
 
-    private String status;
-
-    ReadStatus(String status) {
-        this.status = status;
-    }
+    @Column(name = "user_novel_read_status", nullable = false)
+    private final String status;
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -5,6 +5,7 @@ import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
 import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -14,13 +15,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -30,20 +30,41 @@ public class UserNovel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_novel_id")
     private Long userNovelId;
+
+    @Column(name = "novel_id")
     private Long novelId;
+
+    @Column(name = "user_novel_title", nullable = false)
     private String userNovelTitle;
+
+    @Column(name = "user_novel_author", nullable = false)
     private String userNovelAuthor;
+
+    @Column(name = "user_novel_genre", nullable = false)
     private String userNovelGenre;
+
+    @Column(name = "user_novel_img", nullable = false)
     private String userNovelImg;
+
+    @Column(name = "user_novel_description", nullable = false)
     private String userNovelDescription;
+
+    @Column(name = "user_novel_rating", nullable = false)
     private float userNovelRating;
+
+    @Column(name = "user_novel_read_status", nullable = false)
     private ReadStatus userNovelReadStatus;
+
+    @Column(name = "user_novel_read_start_date")
     private String userNovelReadStartDate;
+
+    @Column(name = "user_novel_read_end_date")
     private String userNovelReadEndDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
@@ -53,7 +74,10 @@ public class UserNovel {
     private List<Platform> platforms = new ArrayList<>();
 
     @Builder
-    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre,
+                     String userNovelImg, String userNovelDescription, float userNovelRating,
+                     ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate,
+                     User user) {
         this.novelId = novelId;
         this.userNovelTitle = userNovelTitle;
         this.userNovelAuthor = userNovelAuthor;

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,5 +1,7 @@
 package com.wss.websoso.userNovel;
 
+import static jakarta.persistence.EnumType.STRING;
+
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
@@ -7,6 +9,7 @@ import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -54,7 +57,7 @@ public class UserNovel {
     @Column(name = "user_novel_rating", nullable = false)
     private float userNovelRating;
 
-    @Column(name = "user_novel_read_status", nullable = false)
+    @Enumerated(value = STRING)
     private ReadStatus userNovelReadStatus;
 
     @Column(name = "user_novel_read_start_date")

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import java.security.Principal;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,12 +21,16 @@ public class UserNovelController {
             @RequestParam String readStatus,
             @RequestParam Long lastUserNovelId,
             @RequestParam int size,
-            @RequestParam String sortType) {
+            @RequestParam String sortType,
+            Principal principal) {
+
+        Long userId = Long.valueOf(principal.getName());
 
         if (Objects.equals(readStatus, "ALL")) {
-            return userNovelService.getUserNovels(lastUserNovelId, size, sortType);
+            return userNovelService.getUserNovels(userId, lastUserNovelId, size, sortType);
         } else {        // OLDEST
-            return userNovelService.getUserNovels(ReadStatus.valueOf(readStatus), lastUserNovelId, size, sortType);
+            return userNovelService.getUserNovels(userId, ReadStatus.valueOf(readStatus),
+                    lastUserNovelId, size, sortType);
         }
     }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -1,0 +1,32 @@
+package com.wss.websoso.userNovel;
+
+import com.wss.websoso.config.ReadStatus;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user-novels")
+public class UserNovelController {
+
+    private final UserNovelService userNovelService;
+
+    @GetMapping
+    public UserNovelsResponse getUserNovels(
+            @RequestParam String readStatus,
+            @RequestParam Long lastUserNovelId,
+            @RequestParam int size,
+            @RequestParam String sortType) {
+
+        if (Objects.equals(readStatus, "ALL")) {
+            return userNovelService.getUserNovels(lastUserNovelId, size, sortType);
+        } else {        // OLDEST
+            return userNovelService.getUserNovels(ReadStatus.valueOf(readStatus), lastUserNovelId, size, sortType);
+        }
+    }
+}
+

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -12,29 +12,38 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
 
     // ALL, NEWEST
     @Query(value = "SELECT un FROM UserNovel un WHERE "
-            + "un.userNovelId < ?1 "
+            + "un.user.userId = ?1 AND "
+            + "un.userNovelId < ?2 "
             + "ORDER BY un.userNovelId DESC")
-    Slice<UserNovel> findUserNovelsByNewest(Long lastUserNovelId, PageRequest pageRequest);
+    Slice<UserNovel> findUserNovelsByNewest(Long userId, Long lastUserNovelId, PageRequest pageRequest);
 
     // ALL, OLDEST
     @Query(value = "SELECT un FROM UserNovel un WHERE "
-            + "un.userNovelId > ?1")
-    Slice<UserNovel> findUserNovelsByOldest(Long lastUserNovelId, PageRequest pageRequest);
+            + "un.user.userId = ?1 AND "
+            + "un.userNovelId > ?2")
+    Slice<UserNovel> findUserNovelsByOldest(Long userId, Long lastUserNovelId, PageRequest pageRequest);
 
     // [FINISH, READING, DROP, WISH], NEWEST
-    @Query(value = "SELECT un FROM UserNovel un "
-            + "WHERE un.userNovelReadStatus = ?1 AND un.userNovelId < ?2 "
+    @Query(value = "SELECT un FROM UserNovel un WHERE "
+            + "un.user.userId = ?1 AND "
+            + "un.userNovelReadStatus = ?2 AND un.userNovelId < ?3 "
             + "ORDER BY un.userNovelId DESC")
-    Slice<UserNovel> findUserNovelsByReadStatusAndNewest(ReadStatus readStatus, Long lastUserNovelId,
-                                                         PageRequest pageRequest);
+    Slice<UserNovel> findUserNovelsByReadStatusAndNewest(Long userId, ReadStatus readStatus,
+                                                         Long lastUserNovelId, PageRequest pageRequest);
 
     // [FINISH, READING, DROP, WISH], OLDEST
-    @Query(value = "SELECT un FROM UserNovel un "
-            + "WHERE un.userNovelReadStatus = ?1 AND un.userNovelId > ?2")
-    Slice<UserNovel> findUserNovelsByReadStatusAndOldest(ReadStatus readStatus, Long lastUserNovelId,
-                                                         PageRequest pageRequest);
+    @Query(value = "SELECT un FROM UserNovel un WHERE "
+            + "un.user.userId = ?1 AND "
+            + "un.userNovelReadStatus = ?2 AND un.userNovelId > ?3 ")
+    Slice<UserNovel> findUserNovelsByReadStatusAndOldest(Long userId, ReadStatus readStatus,
+                                                         Long lastUserNovelId, PageRequest pageRequest);
 
-    long count();
+    @Query(value = "SELECT COUNT(un) FROM UserNovel un WHERE "
+            + "un.user.userId = ?1")
+    long countByUserId(Long userId);
 
-    Long countByUserNovelReadStatus(ReadStatus readStatus);
+    @Query(value = "SELECT COUNT(un) FROM UserNovel un WHERE "
+            + "un.user.userId = ?1 AND "
+            + "un.userNovelReadStatus = ?2")
+    Long countByUserNovelReadStatus(Long userId, ReadStatus readStatus);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -1,8 +1,40 @@
 package com.wss.websoso.userNovel;
 
+import com.wss.websoso.config.ReadStatus;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
+
+    // ALL, NEWEST
+    @Query(value = "SELECT un FROM UserNovel un WHERE "
+            + "un.userNovelId < ?1 "
+            + "ORDER BY un.userNovelId DESC")
+    Slice<UserNovel> findUserNovelsByNewest(Long lastUserNovelId, PageRequest pageRequest);
+
+    // ALL, OLDEST
+    @Query(value = "SELECT un FROM UserNovel un WHERE "
+            + "un.userNovelId > ?1")
+    Slice<UserNovel> findUserNovelsByOldest(Long lastUserNovelId, PageRequest pageRequest);
+
+    // [FINISH, READING, DROP, WISH], NEWEST
+    @Query(value = "SELECT un FROM UserNovel un "
+            + "WHERE un.userNovelReadStatus = ?1 AND un.userNovelId < ?2 "
+            + "ORDER BY un.userNovelId DESC")
+    Slice<UserNovel> findUserNovelsByReadStatusAndNewest(ReadStatus readStatus, Long lastUserNovelId,
+                                                         PageRequest pageRequest);
+
+    // [FINISH, READING, DROP, WISH], OLDEST
+    @Query(value = "SELECT un FROM UserNovel un "
+            + "WHERE un.userNovelReadStatus = ?1 AND un.userNovelId > ?2")
+    Slice<UserNovel> findUserNovelsByReadStatusAndOldest(ReadStatus readStatus, Long lastUserNovelId,
+                                                         PageRequest pageRequest);
+
+    long count();
+
+    Long countByUserNovelReadStatus(ReadStatus readStatus);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
@@ -1,0 +1,10 @@
+package com.wss.websoso.userNovel;
+
+public record UserNovelResponse(
+        Long userNovelId,
+        String userNovelAuthor,
+        String userNovelGenre,
+        String userNovelImg,
+        float userNovelRating
+) {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
@@ -2,6 +2,7 @@ package com.wss.websoso.userNovel;
 
 public record UserNovelResponse(
         Long userNovelId,
+        String userNovelTitle,
         String userNovelAuthor,
         String userNovelGenre,
         String userNovelImg,

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -18,19 +18,19 @@ public class UserNovelService {
     private final UserNovelRepository userNovelRepository;
 
     // ALL
-    public UserNovelsResponse getUserNovels(Long lastUserNovelId, int size, String sortType) {
+    public UserNovelsResponse getUserNovels(Long userId, Long lastUserNovelId, int size, String sortType) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-        long userNovelCount = userNovelRepository.count();
+        long userNovelCount = userNovelRepository.countByUserId(userId);
 
         if (Objects.equals(sortType, "NEWEST")) {
             Slice<UserNovel> entitySlice = userNovelRepository.
-                    findUserNovelsByNewest(lastUserNovelId, pageRequest);
+                    findUserNovelsByNewest(userId, lastUserNovelId, pageRequest);
             List<UserNovel> userNovels = entitySlice.getContent();
 
             return UserNovelsResponse.of(userNovelCount, userNovels);
         } else {      // OLDEST
             Slice<UserNovel> entitySlice = userNovelRepository.
-                    findUserNovelsByOldest(lastUserNovelId, pageRequest);
+                    findUserNovelsByOldest(userId, lastUserNovelId, pageRequest);
             List<UserNovel> userNovels = entitySlice.getContent();
 
             return UserNovelsResponse.of(userNovelCount, userNovels);
@@ -38,19 +38,20 @@ public class UserNovelService {
     }
 
     // [FINISH, READING, DROP, WISH]
-    public UserNovelsResponse getUserNovels(ReadStatus readStatus, Long lastUserNovelId, int size, String sortType) {
+    public UserNovelsResponse getUserNovels(Long userId, ReadStatus readStatus,
+                                            Long lastUserNovelId, int size, String sortType) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-        long userNovelCount = userNovelRepository.countByUserNovelReadStatus(readStatus);
+        long userNovelCount = userNovelRepository.countByUserNovelReadStatus(userId, readStatus);
 
         if (Objects.equals(sortType, "NEWEST")) {
             Slice<UserNovel> entitySlice = userNovelRepository.
-                    findUserNovelsByReadStatusAndNewest(readStatus, lastUserNovelId, pageRequest);
+                    findUserNovelsByReadStatusAndNewest(userId, readStatus, lastUserNovelId, pageRequest);
             List<UserNovel> userNovels = entitySlice.getContent();
 
             return UserNovelsResponse.of(userNovelCount, userNovels);
         } else {      // OLDEST
             Slice<UserNovel> entitySlice = userNovelRepository.
-                    findUserNovelsByReadStatusAndOldest(readStatus, lastUserNovelId, pageRequest);
+                    findUserNovelsByReadStatusAndOldest(userId, readStatus, lastUserNovelId, pageRequest);
             List<UserNovel> userNovels = entitySlice.getContent();
 
             return UserNovelsResponse.of(userNovelCount, userNovels);

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -1,0 +1,59 @@
+package com.wss.websoso.userNovel;
+
+import com.wss.websoso.config.ReadStatus;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserNovelService {
+
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+    private final UserNovelRepository userNovelRepository;
+
+    // ALL
+    public UserNovelsResponse getUserNovels(Long lastUserNovelId, int size, String sortType) {
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
+        long userNovelCount = userNovelRepository.count();
+
+        if (Objects.equals(sortType, "NEWEST")) {
+            Slice<UserNovel> entitySlice = userNovelRepository.
+                    findUserNovelsByNewest(lastUserNovelId, pageRequest);
+            List<UserNovel> userNovels = entitySlice.getContent();
+
+            return UserNovelsResponse.of(userNovelCount, userNovels);
+        } else {      // OLDEST
+            Slice<UserNovel> entitySlice = userNovelRepository.
+                    findUserNovelsByOldest(lastUserNovelId, pageRequest);
+            List<UserNovel> userNovels = entitySlice.getContent();
+
+            return UserNovelsResponse.of(userNovelCount, userNovels);
+        }
+    }
+
+    // [FINISH, READING, DROP, WISH]
+    public UserNovelsResponse getUserNovels(ReadStatus readStatus, Long lastUserNovelId, int size, String sortType) {
+        PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
+        long userNovelCount = userNovelRepository.countByUserNovelReadStatus(readStatus);
+
+        if (Objects.equals(sortType, "NEWEST")) {
+            Slice<UserNovel> entitySlice = userNovelRepository.
+                    findUserNovelsByReadStatusAndNewest(readStatus, lastUserNovelId, pageRequest);
+            List<UserNovel> userNovels = entitySlice.getContent();
+
+            return UserNovelsResponse.of(userNovelCount, userNovels);
+        } else {      // OLDEST
+            Slice<UserNovel> entitySlice = userNovelRepository.
+                    findUserNovelsByReadStatusAndOldest(readStatus, lastUserNovelId, pageRequest);
+            List<UserNovel> userNovels = entitySlice.getContent();
+
+            return UserNovelsResponse.of(userNovelCount, userNovels);
+        }
+    }
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
@@ -1,0 +1,22 @@
+package com.wss.websoso.userNovel;
+
+import java.util.List;
+
+public record UserNovelsResponse(
+        long userNovelCount,
+        List<UserNovelResponse> userNovelList
+) {
+
+    public static UserNovelsResponse of(long userNovelCount, List<UserNovel> userNovels) {
+        List<UserNovelResponse> userNovelList = userNovels.stream()
+                .map(userNovel -> new UserNovelResponse(
+                        userNovel.getUserNovelId(),
+                        userNovel.getUserNovelAuthor(),
+                        userNovel.getUserNovelGenre(),
+                        userNovel.getUserNovelImg(),
+                        userNovel.getUserNovelRating()
+                )).toList();
+
+        return new UserNovelsResponse(userNovelCount, userNovelList);
+    }
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
@@ -11,6 +11,7 @@ public record UserNovelsResponse(
         List<UserNovelResponse> userNovelList = userNovels.stream()
                 .map(userNovel -> new UserNovelResponse(
                         userNovel.getUserNovelId(),
+                        userNovel.getUserNovelTitle(),
                         userNovel.getUserNovelAuthor(),
                         userNovel.getUserNovelGenre(),
                         userNovel.getUserNovelImg(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#20 -> dev
- close #20

## Key Changes
<!-- 최대한 자세히 -->

- `ReadStatus`
  Enum 상수는 코드 레벨에서 값을 명시적으로 참조할 수 있기 때문에 상수와 레이블(label)이 다르면 혼동의 여지가 있다고 생각합니다.
상수와 레이블을 일치시켜 코드 레벨에서의 이해의 명확성을 높이고 일관성을 유지하고자 하는 목적입니다.

- `UserNovel`
  엔티티에서 Nullable 함이 명시되어 있지 않았기에 옵션을 명시했습니다. 

  ReadStatus를 Enum으로 사용하고자 하는 의도와 다르게 DB(mySQL)에서 tinyInt로 사용하는 상태였는데, 이는 개발 전 AOS/iOS와 같이 설계했던 부분과 다르다고 생각하여 enum 자체로 사용할 수 있도록 했습니다.

- `UserNovelController`
  endpoint에서 Query Parameter로 받아오는 readStatus의 경우 DB에서 enum: (FINISH, READING, DROP, WISH) 이외에 ‘ALL’도 존재하기 때문에 분기를 위해 String으로 받고, 존재하는 값인 경우 ReadStatus로 casting 해주었습니다.

- `UserNovelRepository`
  필터링 조건(최신순, 오래된 순)을 적용할 때 sortType에 따라 WHERE 절에서 동적으로 Query 작성이 어려웠기 때문에 메서드 레벨에서 분리했습니다.

  No-Offset 방식을 적용하여 무한 스크롤을 구현해야 하기 때문에 lastUserNovelId, 
readStatus에 따라 데이터를 다르게 가져와야 하기 때문에 readStatus를 적절히 활용하여 JPQL로 작성했습니다.

  간단한 컬럼 개수 조회 JPA method도 사용했습니다.

- `UserNovelService`
  필터링 조건(최신순, 오래된 순)을 적용할 때 sortType에 따라 WHERE 절에서 동적으로 Query 작성이 어려웠기 때문에 repository에서 분리했던 것처럼 service에서도 동일합니다.

- `DTO`
  세미나에서 알게된 정적 팩토리 메서드 패턴을 적용한 of 정적 메서드(static method)를 사용하여 구현했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
1. `UserService`에서 paging과 정렬 관련 로직과 UserNovel 관련 비즈니스 로직을 둘 다 가지고 있어 SRP를 지키지 못한 코드인 것 같습니다. 책임 분리를 위해 로직 개선할 수 있는 방법이 있을까요?
paging과 정렬 관련 로직을 별도 클래스로 추상화하면 좋겠다는 생각이 들기는 합니다.(고민 중)
2. No-Offset 방식 적용 전에 DB에 index 먼저 걸어주는 것이 성능 상 좋을 것이라 판단해서 리팩토링 요소입니다. 
https://jojoldu.tistory.com/528
https://jojoldu.tistory.com/529
3. 개수 조회 관련 JPA method를 사용했는데 성능 개선이 가능하다고 생각합니다.
https://hogwart-scholars.tistory.com/entry/Spring-Boot-count를-구현하는-5가지-방법

함께 고민하고 리팩토링 해봐요~~
