### PR TITLE
[FEAT] 메모 작성 API(POST) 구현 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 /src/main/resources/application.yml
+
+*.yaml
+*.yml
+banner.txt

--- a/src/main/java/com/wss/websoso/memo/Memo.java
+++ b/src/main/java/com/wss/websoso/memo/Memo.java
@@ -2,6 +2,7 @@ package com.wss.websoso.memo;
 
 import com.wss.websoso.config.BaseTimeEntity;
 import com.wss.websoso.userNovel.UserNovel;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -24,6 +25,7 @@ public class Memo extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memoId;
+    @Column(length = 2000)
     private String memoContent;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -1,0 +1,45 @@
+package com.wss.websoso.memo;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/memos")
+@RequiredArgsConstructor
+public class MemoController {
+
+    private final MemoService memoService;
+
+    // 생성
+    @PostMapping("{userNovelId}")
+    public ResponseEntity<Map<String, String>> createMemo(
+            @PathVariable Long userNovelId,
+            @RequestBody MemoCreateRequest request,
+            Principal principal
+    ) {
+        try {
+            URI location = URI.create(memoService.create(Long.valueOf(principal.getName()), userNovelId, request));
+            return ResponseEntity.created(location).build();
+        } catch (IllegalArgumentException e) {
+            if ("내 서재의 작품이 아닙니다.".equals(e.getMessage())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("message", "내 서재의 작품이 아닙니다."));
+            } else if ("memoContent의 최대 길이를 초과했습니다.".equals(e.getMessage())) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Map.of("message", "memoContent의 최대 길이를 초과했습니다."));
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));
+            }
+        }
+    }
+}

--- a/src/main/java/com/wss/websoso/memo/MemoCreateRequest.java
+++ b/src/main/java/com/wss/websoso/memo/MemoCreateRequest.java
@@ -1,0 +1,6 @@
+package com.wss.websoso.memo;
+
+public record MemoCreateRequest(
+        String memoContent
+) {
+}

--- a/src/main/java/com/wss/websoso/memo/MemoRepository.java
+++ b/src/main/java/com/wss/websoso/memo/MemoRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.memo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+}

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -1,0 +1,42 @@
+package com.wss.websoso.memo;
+
+import com.wss.websoso.user.User;
+import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userNovel.UserNovel;
+import com.wss.websoso.userNovel.UserNovelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+    private final UserRepository userRepository;
+    private final UserNovelRepository userNovelRepository;
+
+    @Transactional
+    public String create(Long userId, Long userNovelId, MemoCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        UserNovel userNovel = userNovelRepository.findById(userNovelId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 서재에 없습니다."));
+
+        if (userNovel.getUser() != user){
+            throw new IllegalArgumentException("내 서재의 작품이 아닙니다.");
+        }
+
+        if (request.memoContent().length() > 2000) {
+            throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
+        }
+
+        Memo memo = memoRepository.save(Memo.builder()
+                .memoContent(request.memoContent())
+                .userNovel(userNovel)
+                .build());
+        return memo.getMemoId().toString();
+    }
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.memo.Memo;
 import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
 import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
@@ -14,13 +15,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -52,8 +52,14 @@ public class UserNovel {
     @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Platform> platforms = new ArrayList<>();
 
+    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Memo> memos = new ArrayList<>();
+
     @Builder
-    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre, String userNovelImg, String userNovelDescription, float userNovelRating, ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate, User user) {
+    public UserNovel(Long novelId, String userNovelTitle, String userNovelAuthor, String userNovelGenre,
+                     String userNovelImg, String userNovelDescription, float userNovelRating,
+                     ReadStatus userNovelReadStatus, String userNovelReadStartDate, String userNovelReadEndDate,
+                     User user) {
         this.novelId = novelId;
         this.userNovelTitle = userNovelTitle;
         this.userNovelAuthor = userNovelAuthor;


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#18 -> dev
- close #18 

## Key Changes
<!-- 최대한 자세히 -->
- 메모를 작성하는 API를 구현하였습니다.
- userNovelId, MemoCreateRequest, Principal을 받는 API로, userNovelId는 Path Parameter로 들어갑니다.
- 2000자 이하만 가능하게 설정하였으며, 만약 2000자를 넘을 시 `"memoContent의 최대 길이를 초과했습니다."`라는 메시지를 응답합니다.
- Principal로 받은 user와 userNovel의 user가 일치하지 않을 시 `"내 서재의 작품이 아닙니다."`라는 메시지를 응답합니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 나중에 예외처리 빼고 ResponseEntity 타입 리팩토링 하면서 수정해요~~

## References
<!-- 참고한 자료-->
X