### PR TITLE
[FEAT] 메모 삭제 API(DELETE) 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +37,23 @@ public class MemoController {
             } else if ("memoContent의 최대 길이를 초과했습니다.".equals(e.getMessage())) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .body(Map.of("message", "memoContent의 최대 길이를 초과했습니다."));
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));
+            }
+        }
+    }
+
+    // 삭제
+    @DeleteMapping("{memoId}")
+    public ResponseEntity deleteMemo(@PathVariable Long memoId, Principal principal) {
+        try {
+            memoService.deleteMemo(Long.valueOf(principal.getName()), memoId);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            if ("사용자의 메모가 아닙니다.".equals(e.getMessage())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("message", "사용자의 메모가 아닙니다."));
             } else {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -4,6 +4,7 @@ import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,7 @@ public class MemoService {
         UserNovel userNovel = userNovelRepository.findById(userNovelId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 서재에 없습니다."));
 
-        if (userNovel.getUser() != user){
+        if (userNovel.getUser() != user) {
             throw new IllegalArgumentException("내 서재의 작품이 아닙니다.");
         }
 
@@ -38,5 +39,19 @@ public class MemoService {
                 .userNovel(userNovel)
                 .build());
         return memo.getMemoId().toString();
+    }
+
+    @Transactional
+    public void deleteMemo(Long userId, Long memoId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메모입니다."));
+
+        if (memo.getUserNovel().getUser() != user) {
+            throw new IllegalArgumentException("사용자의 메모가 아닙니다.");
+        }
+        memoRepository.delete(memo);
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#21 -> dev
- close #21 

## Key Changes
<!-- 최대한 자세히 -->
- 메모를 삭제하는 API를 구현하였습니다.
- Path Variable로 memoId를 받아 해당하는 메모를 삭제하며, Principal 또한 받아 사용자의 메모가 맞는지 확인하도록 하였습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X