### PR TITLE
[FEAT] 메모 수정 API(PATCH) 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/memo/Memo.java
+++ b/src/main/java/com/wss/websoso/memo/Memo.java
@@ -37,4 +37,8 @@ public class Memo extends BaseTimeEntity {
         this.memoContent = memoContent;
         this.userNovel = userNovel;
     }
+
+    public void updateContent(String memoContent) {
+        this.memoContent = memoContent;
+    }
 }

--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +34,30 @@ public class MemoController {
             if ("내 서재의 작품이 아닙니다.".equals(e.getMessage())) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN)
                         .body(Map.of("message", "내 서재의 작품이 아닙니다."));
+            } else if ("memoContent의 최대 길이를 초과했습니다.".equals(e.getMessage())) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Map.of("message", "memoContent의 최대 길이를 초과했습니다."));
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));
+            }
+        }
+    }
+
+    // 수정
+    @PatchMapping("{memoId}")
+    public ResponseEntity<Map<String, String>> editMemo(
+            @PathVariable Long memoId,
+            @RequestBody MemoUpdateRequest request,
+            Principal principal
+    ) {
+        try {
+            memoService.editMemo(Long.valueOf(principal.getName()), memoId, request);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            if ("사용자의 메모가 아닙니다.".equals(e.getMessage())) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("message", "사용자의 메모가 아닙니다."));
             } else if ("memoContent의 최대 길이를 초과했습니다.".equals(e.getMessage())) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                         .body(Map.of("message", "memoContent의 최대 길이를 초과했습니다."));

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -4,6 +4,7 @@ import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,7 @@ public class MemoService {
         UserNovel userNovel = userNovelRepository.findById(userNovelId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 서재에 없습니다."));
 
-        if (userNovel.getUser() != user){
+        if (userNovel.getUser() != user) {
             throw new IllegalArgumentException("내 서재의 작품이 아닙니다.");
         }
 
@@ -38,5 +39,24 @@ public class MemoService {
                 .userNovel(userNovel)
                 .build());
         return memo.getMemoId().toString();
+    }
+
+    @Transactional
+    public void editMemo(Long userId, Long memoId, MemoUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 메모가 없습니다."));
+
+        if (memo.getUserNovel().getUser() != user) {
+            throw new IllegalArgumentException("사용자의 메모가 아닙니다.");
+        }
+
+        if (request.memoContent().length() > 2000) {
+            throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
+        }
+
+        memo.updateContent(request.memoContent());
     }
 }

--- a/src/main/java/com/wss/websoso/memo/MemoUpdateRequest.java
+++ b/src/main/java/com/wss/websoso/memo/MemoUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.wss.websoso.memo;
+
+public record MemoUpdateRequest(
+        String memoContent
+) {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#29 -> dev
- close #29 

## Key Changes
<!-- 최대한 자세히 -->
- 메모 수정 PATCH API를 구현하였습니다.
- memoId, MemoUpdateRequest, Principal을 매개변수로 받으며, memoId가 Path variable로 들어와 해당하는 memo를 수정합니다.
- 메모의 memoContent만 수정가능하며, 수정할 때에도 post와 마찬가지로 2000자를 초과하면 Exception이 응답됩니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X