### PR TITLE
[FEAT] 기록에서 메모 전체 조회 API(GET) 구현 완료

### DIFF
--- a/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
+++ b/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
@@ -3,20 +3,21 @@ package com.wss.websoso.config;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
-      @CreatedDate // 생성 시각, 현재 시각으로 초기화 해줌!
-      private String createdDate;
+    @CreatedDate // 생성 시각, 현재 시각으로 초기화 해줌!
+    private String createdDate;
 
-      @PrePersist
-      public void onPrePersist() {
-            this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm"));
-      }
+    @PrePersist
+    public void onPrePersist() {
+        this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm"));
+    }
 }

--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -6,10 +6,12 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,5 +43,15 @@ public class MemoController {
                         .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));
             }
         }
+    }
+
+    // 서재 메모 전체 조회
+    @GetMapping
+    public MemosGetResponse getMemos(
+            @RequestParam Long lastMemoId,
+            @RequestParam int size,
+            @RequestParam String sortType,
+            Principal principal) {
+        return memoService.getMemos(Long.valueOf(principal.getName()), lastMemoId, size, sortType);
     }
 }

--- a/src/main/java/com/wss/websoso/memo/MemoGetResponse.java
+++ b/src/main/java/com/wss/websoso/memo/MemoGetResponse.java
@@ -1,0 +1,9 @@
+package com.wss.websoso.memo;
+
+public record MemoGetResponse(
+        Long memoId,
+        String novelTitle,
+        String memoContent,
+        String memoDate
+) {
+}

--- a/src/main/java/com/wss/websoso/memo/MemoRepository.java
+++ b/src/main/java/com/wss/websoso/memo/MemoRepository.java
@@ -1,8 +1,31 @@
 package com.wss.websoso.memo;
 
+import com.wss.websoso.userNovel.UserNovel;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
+    List<Memo> findAllByUserNovelIn(List<UserNovel> userNovels);
+
+    // NEWEST
+    @Query(value = "SELECT m FROM Memo m WHERE "
+            + "m.userNovel.user.userId = ?1 AND "
+            + "m.memoId < ?2 "
+            + "ORDER BY m.memoId DESC")
+    Slice<Memo> findMemosByNewest(Long userId, Long lastMemoId, PageRequest pageRequest);
+
+    // OLDEST
+    @Query(value = "SELECT m FROM Memo m WHERE "
+            + "m.userNovel.user.userId = ?1 AND "
+            + "m.memoId > ?2 ")
+    Slice<Memo> findMemosByOldest(Long userId, Long lastMemoId, PageRequest pageRequest);
+
+    @Query(value = "SELECT COUNT(m) FROM Memo m WHERE "
+            + "m.userNovel.user.userId = ?1")
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/wss/websoso/memo/MemosGetResponse.java
+++ b/src/main/java/com/wss/websoso/memo/MemosGetResponse.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.memo;
+
+import java.util.List;
+
+public record MemosGetResponse(
+        long memoCount,
+        List<MemoGetResponse> memoList
+) {
+    public static MemosGetResponse of(long memoCount, List<Memo> memos) {
+        List<MemoGetResponse> memoList = memos.stream()
+                .map(memo -> new MemoGetResponse(
+                        memo.getMemoId(),
+                        memo.getUserNovel().getUserNovelTitle(),
+                        memo.getMemoContent(),
+                        memo.getCreatedDate()
+                )).toList();
+        return new MemosGetResponse(memoCount, memoList);
+    }
+}


### PR DESCRIPTION
최신순, 오래된순으로 각각 정렬될 수 있으며 무한스크롤로 사용자의 전체 조회

## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#28 -> dev
- close #28 

## Key Changes
<!-- 최대한 자세히 -->
- 최신순, 오래된순 둘 중 하나로 정렬하여 전체 메모를 No Offset 무한스크롤로 조회할 수 있는 API를 구현하였습니다.
- lastMemoId, size, sortType, principal을 매개로 받으며, 한번에 size만큼씩 조회됩니다.
- sortType은 NEWEST, OLDEST 중 하나가 됩니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 전반적으로 서재 작품 목록 조회 API와 유사합니다!

## References
<!-- 참고한 자료-->
X