### PR TITLE
[FIX] 작품 검색 API 누락 코드 복구, 반환 타입 수정

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,11 +26,11 @@ public class NovelController {
     word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
      */
     @GetMapping
-    public List<NovelGetResponse> getNovelsByWord(
+    public ResponseEntity<NovelsGetResponse> getNovelsByWord(
             @RequestParam Long lastNovelId,
             @RequestParam int size,
             @RequestParam String word) {
-        return novelService.getNovelsByWord(lastNovelId, size, word);
+        return ResponseEntity.ok().body(novelService.getNovelsByWord(lastNovelId, size, word));
     }
 
     @GetMapping("{novelId}")

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -35,10 +34,10 @@ public class NovelService {
     private final KeywordRepository keywordRepository;
     private final PlatformRepository platformRepository;
 
-    public List<NovelGetResponse> getNovelsByWord(Long lastNovelId, int size, String word) {
+    public NovelsGetResponse getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);
-        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word);
-        return entitySlice.getContent().stream()
+        Slice<Novel> entitySlice = novelRepository.findByIdLessThanOrderByIdDesc(lastNovelId, pageRequest, word.replaceAll(" ", ""));
+        return new NovelsGetResponse(entitySlice.getContent().stream()
                 .map(novel -> new NovelGetResponse(
                         novel.getNovelId(),
                         novel.getNovelTitle(),
@@ -46,7 +45,7 @@ public class NovelService {
                         novel.getNovelGenre(),
                         novel.getNovelImg()
                 ))
-                .toList();
+                .toList());
     }
 
     public ResponseEntity<?> getNovelByNovelId(Long novelId, Long userId) {

--- a/src/main/java/com/wss/websoso/novel/NovelsGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/NovelsGetResponse.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.novel;
+
+import java.util.List;
+
+public record NovelsGetResponse(
+        List<NovelGetResponse> novelList
+) {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#38 -> dev
- close #38

## Key Changes
<!-- 최대한 자세히 -->
dev 브랜치에 머지하는 과정에서 conflict를 해결하다 작품 검색 API의 검색어 공백을 제거하는 로직이 누락되어, 복구했습니다.
작품 검색 API의 반환값을 명세와 일치하도록 `NovelsGetResponse` 클래스를 생성해서 기존 반환값을 넣고, 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X