### PR TITLE
[REMOVE] 키워드 관련 로직 삭제

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -1,17 +1,13 @@
 package com.wss.websoso.novel;
 
-import com.wss.websoso.userNovel.UserNovelCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 import java.security.Principal;
 import java.util.List;
 
@@ -37,19 +33,5 @@ public class NovelController {
     @GetMapping("{novelId}")
     public ResponseEntity getNovelByNovelId(@PathVariable Long novelId, Principal principal) {
         return novelService.getNovelByNovelId(novelId, Long.valueOf(principal.getName()));
-    }
-
-    @PostMapping("{novelId}")
-    public ResponseEntity<Void> createUserNovel(
-            @PathVariable Long novelId,
-            @RequestBody UserNovelCreateRequest userNovelCreateRequest,
-            Principal principal) {
-        URI location = URI.create("/userNovels/" + novelService.createUserNovel(
-                novelId,
-                Long.valueOf(principal.getName()),
-                userNovelCreateRequest)
-        );
-
-        return ResponseEntity.created(location).build();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,19 +1,12 @@
 package com.wss.websoso.novel;
 
-import com.wss.websoso.config.ReadStatus;
-import com.wss.websoso.keyword.Keyword;
-import com.wss.websoso.keyword.KeywordRepository;
-import com.wss.websoso.platform.Platform;
 import com.wss.websoso.platform.PlatformGetResponse;
 import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
-import com.wss.websoso.userNovel.UserNovelCreateRequest;
 import com.wss.websoso.userNovel.UserNovelGetResponse;
 import com.wss.websoso.userNovel.UserNovelRepository;
-import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
-import com.wss.websoso.userNovelKeyword.UserNovelKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -21,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +23,6 @@ public class NovelService {
     private final NovelRepository novelRepository;
     private final UserRepository userRepository;
     private final UserNovelRepository userNovelRepository;
-    private final UserNovelKeywordRepository userNovelKeywordRepository;
-    private final KeywordRepository keywordRepository;
     private final PlatformRepository platformRepository;
 
     public List<NovelGetResponse> getNovelsByWord(Long lastNovelId, int size, String word) {
@@ -71,9 +61,6 @@ public class NovelService {
                     userNovel.getUserNovelReadStatus(),
                     userNovel.getUserNovelReadStartDate(),
                     userNovel.getUserNovelReadEndDate(),
-                    userNovel.getUserNovelKeywords().stream()
-                            .map(userNovelKeyword -> userNovelKeyword.getKeyword().getKeywordName())
-                            .toList(),
                     userNovel.getPlatforms().stream()
                             .map(platform -> new PlatformGetResponse(
                                     platform.getPlatformName(),
@@ -97,63 +84,5 @@ public class NovelService {
                             .toList()
             ));
         }
-    }
-
-    public Long createUserNovel(Long novelId, Long userId, UserNovelCreateRequest userNovelCreateRequest) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
-
-        Novel novel = novelRepository.findById(novelId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
-
-        UserNovel userNovel = UserNovel.builder()
-                .novelId(novelId)
-                .userNovelTitle(novel.getNovelTitle())
-                .userNovelAuthor(novel.getNovelAuthor())
-                .userNovelGenre(novel.getNovelGenre())
-                .userNovelImg(novel.getNovelImg())
-                .userNovelDescription(novel.getNovelDescription())
-                .userNovelRating(userNovelCreateRequest.novelRating())
-                .userNovelReadStatus(ReadStatus.valueOf(userNovelCreateRequest.novelReadStatus()))
-                .userNovelReadStartDate(userNovelCreateRequest.novelReadStartDate())
-                .userNovelReadEndDate(userNovelCreateRequest.novelReadEndDate())
-                .user(user)
-                .build();
-
-        userNovelRepository.save(userNovel);
-
-        if (novel.getPlatforms() != null) {
-            novel.getPlatforms().stream()
-                    .forEach(platform -> {
-                        Platform newPlatform = Platform.builderWithUserNovel()
-                                .platformName(platform.getPlatformName())
-                                .platformUrl(platform.getPlatformUrl())
-                                .userNovel(userNovel)
-                                .buildWithUserNovel();
-
-                        platformRepository.save(newPlatform);
-                    });
-        }
-
-        if (userNovelCreateRequest.keywordNames() != null) {
-            userNovelCreateRequest.keywordNames().stream()
-                    .map(keywordName -> {
-                        Optional<Keyword> optionalKeyword = keywordRepository.findByKeywordName(keywordName);
-                        if (optionalKeyword.isEmpty()) {
-                            throw new IllegalArgumentException("해당하는 키워드가 없습니다.");
-                        }
-                        return optionalKeyword.get();
-                    })
-                    .forEach(keyword -> {
-                        UserNovelKeyword userNovelKeyword = UserNovelKeyword.builder()
-                                .userNovel(userNovel)
-                                .keyword(keyword)
-                                .build();
-
-                        userNovelKeywordRepository.save(userNovelKeyword);
-                    });
-        }
-
-        return userNovel.getUserNovelId();
     }
 }

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -1,7 +1,6 @@
 package com.wss.websoso.novel;
 
 import com.wss.websoso.platform.PlatformGetResponse;
-import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
@@ -23,7 +22,6 @@ public class NovelService {
     private final NovelRepository novelRepository;
     private final UserRepository userRepository;
     private final UserNovelRepository userNovelRepository;
-    private final PlatformRepository platformRepository;
 
     public List<NovelGetResponse> getNovelsByWord(Long lastNovelId, int size, String word) {
         PageRequest pageRequest = PageRequest.of(DEFAULT_PAGE_NUMBER, size);

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -1,12 +1,9 @@
 package com.wss.websoso.userNovel;
 
-import static jakarta.persistence.EnumType.STRING;
-
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.memo.Memo;
 import com.wss.websoso.platform.Platform;
 import com.wss.websoso.user.User;
-import com.wss.websoso.userNovelKeyword.UserNovelKeyword;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,12 +16,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.EnumType.STRING;
 
 @Entity
 @Getter
@@ -70,9 +70,6 @@ public class UserNovel {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<UserNovelKeyword> userNovelKeywords;
 
     @OneToMany(mappedBy = "userNovel", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Platform> platforms = new ArrayList<>();

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -1,16 +1,20 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
-import java.security.Principal;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +22,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserNovelController {
 
     private final UserNovelService userNovelService;
+
+    @PostMapping("{novelId}")
+    public ResponseEntity<Void> createUserNovel(
+            @PathVariable Long novelId,
+            @RequestBody UserNovelCreateRequest userNovelCreateRequest,
+            Principal principal) {
+        URI location = URI.create("/userNovels/" + userNovelService.createUserNovel(
+                novelId,
+                Long.valueOf(principal.getName()),
+                userNovelCreateRequest)
+        );
+
+        return ResponseEntity.created(location).build();
+    }
 
     @GetMapping
     public UserNovelsResponse getUserNovels(

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelCreateRequest.java
@@ -1,12 +1,9 @@
 package com.wss.websoso.userNovel;
 
-import java.util.List;
-
 public record UserNovelCreateRequest(
-        float novelRating,
-        String novelReadStatus,
-        String novelReadStartDate,
-        String novelReadEndDate,
-        List<String> keywordNames
+        float userNovelRating,
+        String userNovelReadStatus,
+        String userNovelReadStartDate,
+        String userNovelReadEndDate
 ) {
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelGetResponse.java
@@ -16,7 +16,6 @@ public record UserNovelGetResponse(
         ReadStatus userNovelReadStatus,
         String userNovelReadStartDate,
         String userNovelReadEndDate,
-        List<String> keywords,
         List<PlatformGetResponse> platforms
 ) {
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- remove/#39 -> dev
- close #39
- close #40 


## Key Changes
<!-- 최대한 자세히 -->
- 기능 요구사항에서 키워드 관련 로직이 삭제되어, 구현해두었던 키워드 관련 모든 로직을 삭제했습니다.
  - 키워드 도메인과 같은 서비스에 영향을 주지 않는 코드는 삭제하지 않았습니다.
- 서재 작품 등록 API (POST) 엔드포인트 변경 `(기존: novels/{novelId}, 변경 후: user-novels/{novelId})` 으로 인해, 해당 API 관련 로직을 UserNovelController, UserNovelService 로 옮겼습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X