### PR TITLE
[REMOVE] 서재 작품 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -20,7 +20,7 @@ public class UserNovelController {
     private final UserNovelService userNovelService;
 
     @GetMapping
-    public UserNovelsResponse getUserNovels(
+    public ResponseEntity<UserNovelsResponse> getUserNovels(
             @RequestParam String readStatus,
             @RequestParam Long lastUserNovelId,
             @RequestParam int size,
@@ -30,10 +30,14 @@ public class UserNovelController {
         Long userId = Long.valueOf(principal.getName());
 
         if (Objects.equals(readStatus, "ALL")) {
-            return userNovelService.getUserNovels(userId, lastUserNovelId, size, sortType);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(userNovelService.getUserNovels(userId, lastUserNovelId, size, sortType));
         } else {        // OLDEST
-            return userNovelService.getUserNovels(userId, ReadStatus.valueOf(readStatus),
-                    lastUserNovelId, size, sortType);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(userNovelService.getUserNovels(userId, ReadStatus.valueOf(readStatus),
+                            lastUserNovelId, size, sortType));
         }
     }
 

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelResponse.java
@@ -3,9 +3,8 @@ package com.wss.websoso.userNovel;
 public record UserNovelResponse(
         Long userNovelId,
         String userNovelTitle,
-        String userNovelAuthor,
-        String userNovelGenre,
         String userNovelImg,
+        String userNovelAuthor,
         float userNovelRating
 ) {
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelsResponse.java
@@ -12,9 +12,8 @@ public record UserNovelsResponse(
                 .map(userNovel -> new UserNovelResponse(
                         userNovel.getUserNovelId(),
                         userNovel.getUserNovelTitle(),
-                        userNovel.getUserNovelAuthor(),
-                        userNovel.getUserNovelGenre(),
                         userNovel.getUserNovelImg(),
+                        userNovel.getUserNovelAuthor(),
                         userNovel.getUserNovelRating()
                 )).toList();
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- remove/#41 -> dev
- close #41

## Key Changes
<!-- 최대한 자세히 -->
서재 작품 목록 조회 API의 반환값에서 UserNovelsResponse DTO에서 장르(userNovelGenre) 제외