### PR TITLE
[FIX] 서재 작품 메모&정보 조회 API 수정

### DIFF
--- a/src/main/java/com/wss/websoso/genreBadge/GenreBadgeRepository.java
+++ b/src/main/java/com/wss/websoso/genreBadge/GenreBadgeRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.genreBadge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GenreBadgeRepository extends JpaRepository<GenreBadge, Long> {
+
+    GenreBadge findByGenreBadgeName(String genreBadge);
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelMemoAndInfoGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelMemoAndInfoGetResponse.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.genreBadge.GenreBadge;
 import com.wss.websoso.memo.Memo;
 import com.wss.websoso.platform.Platform;
 import java.util.List;
@@ -13,10 +14,12 @@ public record UserNovelMemoAndInfoGetResponse(
         String userNovelReadEndDate,
         String userNovelDescription,
         String userNovelGenre,
+        String userNovelGenreBadgeImg,
         List<UserNovelPlatformsGetResponse> platformList
 ) {
 
-    public static UserNovelMemoAndInfoGetResponse of(List<Memo> memos, UserNovel userNovel, List<Platform> platforms) {
+    public static UserNovelMemoAndInfoGetResponse of(List<Memo> memos, UserNovel userNovel,
+                                                     List<Platform> platforms, GenreBadge genreBadge) {
         List<UserNovelMemosGetResponse> memoList = memos.stream()
                 .map(memo -> new UserNovelMemosGetResponse(
                         memo.getMemoId(),
@@ -38,6 +41,7 @@ public record UserNovelMemoAndInfoGetResponse(
                 userNovel.getUserNovelReadEndDate(),
                 userNovel.getUserNovelDescription(),
                 userNovel.getUserNovelGenre(),
+                genreBadge.getGenreBadgeImg(),
                 platformList
         );
     }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -1,6 +1,8 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.genreBadge.GenreBadge;
+import com.wss.websoso.genreBadge.GenreBadgeRepository;
 import com.wss.websoso.memo.Memo;
 import com.wss.websoso.memo.MemoRepository;
 import com.wss.websoso.novel.Novel;
@@ -9,14 +11,13 @@ import com.wss.websoso.platform.Platform;
 import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class UserNovelService {
     private final PlatformRepository platformRepository;
     private final UserRepository userRepository;
     private final NovelRepository novelRepository;
+    private final GenreBadgeRepository genreBadgeRepository;
 
     @Transactional
     public Long createUserNovel(Long novelId, Long userId, UserNovelCreateRequest userNovelCreateRequest) {
@@ -124,7 +126,8 @@ public class UserNovelService {
         List<Memo> memos = memoRepository.findByUserNovelId(userNovelId);
         List<Platform> platforms = platformRepository.findByUserNovelId(userNovelId);
         UserNovel userNovel = userNovelRepository.findByUserNovelId(userNovelId);
+        GenreBadge genreBadge = genreBadgeRepository.findByGenreBadgeName(userNovel.getUserNovelGenre());
 
-        return UserNovelMemoAndInfoGetResponse.of(memos, userNovel, platforms);
+        return UserNovelMemoAndInfoGetResponse.of(memos, userNovel, platforms, genreBadge);
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#42 -> dev
- close #42

## Key Changes
<!-- 최대한 자세히 -->
서재 내 작품의 메모와 정보 조회 API에서 장르의 뱃지를 나타내는 이미지도 보내주어야 하기 때문에,
GenreBadge 리포지토리에 메서드를 구현하고, UserNovelMemoAndInfoGetResponse DTO에 userNovelGenreBadgeImg를 추가하여 내려준다.