### PR TITLE
[FEAT] 서재에서 작품 수정 API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -93,4 +93,14 @@ public class UserNovel {
         this.userNovelReadEndDate = userNovelReadEndDate;
         this.user = user;
     }
+
+    public void update(float userNovelRating,
+                       String userNovelReadStatus,
+                       String userNovelReadStartDate,
+                       String userNovelReadEndDate) {
+        this.userNovelRating = userNovelRating;
+        this.userNovelReadStatus = ReadStatus.valueOf(userNovelReadStatus);
+        this.userNovelReadStartDate = userNovelReadStartDate;
+        this.userNovelReadEndDate = userNovelReadEndDate;
+    }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -75,6 +76,19 @@ public class UserNovelController {
 
         Long userId = Long.valueOf(principal.getName());
         userNovelService.deleteUserNovel(userId, userNovelId);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+
+    @PatchMapping("/{userNovelId}")
+    public ResponseEntity<Void> updateUserNovel(@PathVariable Long userNovelId,
+                                                @RequestBody UserNovelUpdateRequest userNovelUpdateRequest,
+                                                Principal principal) {
+
+        Long userId = Long.valueOf(principal.getName());
+        userNovelService.updateUserNovel(userId, userNovelId, userNovelUpdateRequest);
 
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -146,4 +146,22 @@ public class UserNovelService {
 
         userNovelRepository.delete(userNovel);
     }
+
+    @Transactional
+    public void updateUserNovel(Long userId, Long userNovelId, UserNovelUpdateRequest userNovelUpdateRequest) {
+        UserNovel userNovelForAuthorization = userNovelRepository.findById(userNovelId)
+                .orElseThrow(() -> new RuntimeException("해당하는 userNovel이 없습니다."));
+
+        Long userIdForAuthorization = userNovelForAuthorization.getUser().getUserId();
+        if (!Objects.equals(userIdForAuthorization, userId)) {
+            throw new RuntimeException("잘못된 접근입니다.(인가X)");
+        }
+
+        UserNovel userNovel = userNovelRepository.findByUserNovelId(userNovelId);
+        userNovel.update(
+                userNovelUpdateRequest.userNovelRating(),
+                userNovelUpdateRequest.userNovelReadStatus(),
+                userNovelUpdateRequest.userNovelReadStartDate(),
+                userNovelUpdateRequest.userNovelReadEndDate());
+    }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelUpdateRequest.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.wss.websoso.userNovel;
+
+public record UserNovelUpdateRequest(
+        float userNovelRating,
+        String userNovelReadStatus,
+        String userNovelReadStartDate,
+        String userNovelReadEndDate
+) {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#52 -> dev
- close #52

## Key Changes
<!-- 최대한 자세히 -->
user의 userNovel이 맞는지 확인하고,
userNovelId로 userNovel을 찾고,
userNovel의 정보 중 userNovelRating, userNovelReadStatus, userNovelReadStartDate, userNovelReadEndDate를 수정한다.
성공 시 204 status code를 반환하는 간단한 API입니다.