### PR TITLE
[FEAT] 소소's pick API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -68,4 +68,11 @@ public class UserNovelController {
                 .status(HttpStatus.OK)
                 .body(userNovelService.getUserNovelMemoAndInfo(userId, userNovelId));
     }
+
+    @GetMapping("/soso-picks")
+    public ResponseEntity<sosoPicksGetResponse> getSosoPicks() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userNovelService.getSosoPicks());
+    }
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -2,12 +2,13 @@ package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.user.User;
-import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
@@ -52,4 +53,9 @@ public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {
     Long countByUserNovelReadStatus(Long userId, ReadStatus readStatus);
 
     UserNovel findByUserNovelId(Long userNovelId);
+
+    @Query(value = "SELECT MAX(un.userNovelId) FROM UserNovel un")
+    Optional<Long> findByMaxUserNovelId();
+
+    Long countUserNovelsByNovelId(Long novelId);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -11,13 +11,16 @@ import com.wss.websoso.platform.Platform;
 import com.wss.websoso.platform.PlatformRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -129,5 +132,38 @@ public class UserNovelService {
         GenreBadge genreBadge = genreBadgeRepository.findByGenreBadgeName(userNovel.getUserNovelGenre());
 
         return UserNovelMemoAndInfoGetResponse.of(memos, userNovel, platforms, genreBadge);
+    }
+
+    public sosoPicksGetResponse getSosoPicks() {
+        Long lastUserNovelId;
+        try {
+            lastUserNovelId = userNovelRepository.findByMaxUserNovelId()
+                    .orElseThrow(() -> new RuntimeException("유저가 등록한 서재 작품이 없습니다."));
+        } catch (Exception e) {
+            return new sosoPicksGetResponse(new ArrayList<>());
+        }
+        List<Novel> recentNovels = new ArrayList<>();
+        int count = 0;
+        while (count < 10 && lastUserNovelId >= 0) {
+            Optional<UserNovel> userNovel = userNovelRepository.findById(lastUserNovelId);
+
+            if (!userNovel.isEmpty()) {
+                Novel novel = novelRepository.findById(userNovel.get().getNovelId())
+                        .orElseThrow(() -> new RuntimeException("해당하는 작품이 없습니다."));
+
+                if (!recentNovels.contains(novel)) {
+                    recentNovels.add(novel);
+                    count++;
+                }
+            }
+
+            lastUserNovelId--;
+        }
+
+        List<sosoPickGetResponse> sosoPicks = recentNovels.stream()
+                .map(novel -> sosoPickGetResponse.of(novel, userNovelRepository.countUserNovelsByNovelId(novel.getNovelId())))
+                .toList();
+
+        return new sosoPicksGetResponse(sosoPicks);
     }
 }

--- a/src/main/java/com/wss/websoso/userNovel/sosoPickGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/sosoPickGetResponse.java
@@ -1,0 +1,14 @@
+package com.wss.websoso.userNovel;
+
+import com.wss.websoso.novel.Novel;
+
+public record sosoPickGetResponse(
+        String novelImg,
+        String novelTitle,
+        String novelAuthor,
+        Long novelRegisteredCount
+) {
+    public static sosoPickGetResponse of(Novel novel, Long novelRegisteredCount) {
+        return new sosoPickGetResponse(novel.getNovelImg(), novel.getNovelTitle(), novel.getNovelAuthor(), novelRegisteredCount);
+    }
+}

--- a/src/main/java/com/wss/websoso/userNovel/sosoPicksGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/sosoPicksGetResponse.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.userNovel;
+
+import java.util.List;
+
+public record sosoPicksGetResponse(
+        List<sosoPickGetResponse> sosoPickNovelList
+) {
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#33 -> dev
- close #33

## Key Changes
<!-- 최대한 자세히 -->
전체 유저가 등록한 작품 중 중복을 제거하고 최근 10개의 작품 정보를 조회하는 API를 구현했습니다.
작품 정보에는 명세서와 일치하게 작품 이미지, 제목, 작가, 해당 작품을 등록한 유저 수 정보가 들어있습니다.
해당 API의 동작 흐름은 다음과 같습니다.
1. userNovelRepository.findByMaxUserNovelId() 를 통해 가장 최근에 등록한 userNovelId를 알아냄
   - 이때, 유저가 등록한 서재 작품이 하나도 없을 경우 DTO에 빈 리스트를 넣어 반환
2. 가장 최근에 등록한 userNovelId를 1씩 줄여가며 서재 작품을 조회하고 recentNovels에 넣음
   - userNovelId가 0 이하가 되면 더 이상 조회 X
   - count 변수(10개 조회했는지 확인용) 가 10 이상이 되면 더 이상 조회 X
   - recentNovels에 현재 userNovelId로 조회한 UserNovel이 있다면 recentNovels에 넣지 않음

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X