### PR TITLE
[FEAT] 메모 조회(단건) API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -1,8 +1,5 @@
 package com.wss.websoso.memo;
 
-import java.net.URI;
-import java.security.Principal;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/memos")
@@ -55,6 +56,14 @@ public class MemoController {
             @RequestParam String sortType,
             Principal principal) {
         return memoService.getMemos(Long.valueOf(principal.getName()), lastMemoId, size, sortType);
+    }
+
+    @GetMapping("{memoId}")
+    public ResponseEntity<MemoDetailGetResponse> getMemo(@PathVariable Long memoId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(memoService.getMemo(memoId, userId));
     }
 
     // 삭제

--- a/src/main/java/com/wss/websoso/memo/MemoDetailGetResponse.java
+++ b/src/main/java/com/wss/websoso/memo/MemoDetailGetResponse.java
@@ -1,0 +1,19 @@
+package com.wss.websoso.memo;
+
+public record MemoDetailGetResponse(
+        String userNovelTitle,
+        String userNovelImg,
+        String userNovelAuthor,
+        String memoDate,
+        String memoContent
+) {
+    public static MemoDetailGetResponse of(Memo memo) {
+        return new MemoDetailGetResponse(
+                memo.getUserNovel().getUserNovelTitle(),
+                memo.getUserNovel().getUserNovelImg(),
+                memo.getUserNovel().getUserNovelAuthor(),
+                memo.getCreatedDate(),
+                memo.getMemoContent()
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -5,13 +5,14 @@ import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -59,6 +60,17 @@ public class MemoService {
             List<Memo> memos = entitySlice.getContent();
             return MemosGetResponse.of(memoCount, memos);
         }
+    }
+
+    public MemoDetailGetResponse getMemo(Long memoId, Long userId) {
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 메모입니다."));
+
+        if (memo.getUserNovel().getUser().getUserId() != userId) {
+            throw new IllegalArgumentException("사용자의 메모가 아닙니다.");
+        }
+
+        return MemoDetailGetResponse.of(memo);
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#56 -> dev
- close #56

## Key Changes
<!-- 최대한 자세히 -->
- memoId를 받아, 해당 memoId를 가지는 memo의 정보를 조회
- 현재 로그인한 유저의 메모가 아니면 에러를 발생시킴
- 명세에 따라 Response DTO를 사용해, 데이터를 가공하여 반환