### PR TITLE
[FEAT] 유저 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/avatar/AvatarRepository.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarRepository.java
@@ -1,0 +1,7 @@
+package com.wss.websoso.avatar;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+
+}

--- a/src/main/java/com/wss/websoso/avatarLine/AvatarLineRepository.java
+++ b/src/main/java/com/wss/websoso/avatarLine/AvatarLineRepository.java
@@ -1,0 +1,11 @@
+package com.wss.websoso.avatarLine;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AvatarLineRepository extends JpaRepository<AvatarLine, Long> {
+
+    @Query(value = "SELECT al FROM AvatarLine al WHERE al.avatar.avatarId = ?1")
+    List<AvatarLine> findByAvatarId(Long avatarId);
+}

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -1,6 +1,7 @@
 package com.wss.websoso.user;
 
 import com.wss.websoso.userAvatar.UserAvatar;
+import com.wss.websoso.userNovel.UserNovel;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,4 +32,7 @@ public class User {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserAvatar> userAvatars;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<UserNovel> userNovels;
 }

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -31,10 +32,10 @@ public class User {
     private Long userRepAvatarId;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<UserAvatar> userAvatars;
+    private List<UserAvatar> userAvatars = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<UserNovel> userNovels;
+    private List<UserNovel> userNovels = new ArrayList<>();
 
     public int getMemoCount() {
         int memoCount = 0;

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -35,4 +35,12 @@ public class User {
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserNovel> userNovels;
+
+    public int getMemoCount() {
+        int memoCount = 0;
+        for (UserNovel userNovel : getUserNovels()) {
+            memoCount += userNovel.getMemos().size();
+        }
+        return memoCount;
+    }
 }

--- a/src/main/java/com/wss/websoso/user/UserController.java
+++ b/src/main/java/com/wss/websoso/user/UserController.java
@@ -1,8 +1,11 @@
 package com.wss.websoso.user;
 
 import jakarta.security.auth.message.AuthException;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,5 +25,14 @@ public class UserController {
         } catch (AuthException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
+    }
+
+    @GetMapping("/user-info")
+    public ResponseEntity<UserInfoGetResponse> getUserInfo(Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.getUserInfo(userId));
     }
 }

--- a/src/main/java/com/wss/websoso/user/UserInfoGetResponse.java
+++ b/src/main/java/com/wss/websoso/user/UserInfoGetResponse.java
@@ -1,0 +1,34 @@
+package com.wss.websoso.user;
+
+import com.wss.websoso.avatar.Avatar;
+import com.wss.websoso.avatarLine.AvatarLine;
+import com.wss.websoso.userNovel.UserAvatarsGetResponse;
+import java.util.List;
+
+public record UserInfoGetResponse(
+        Long representativeAvatarId,
+        String representativeAvatarGenreBadge,
+        String representativeAvatarTag,
+        String representativeAvatarLineContent,
+        String representativeAvatarImg,
+        String userNickName,
+        long userNovelCount,
+        long memoCount,
+        List<UserAvatarsGetResponse> userAvatarList
+) {
+    public static UserInfoGetResponse of(User user, Avatar avatar, long userNovelCount,
+                                         AvatarLine avatarLine, long memoCount,
+                                         List<UserAvatarsGetResponse> avatars) {
+        return new UserInfoGetResponse(
+                user.getUserRepAvatarId(),
+                avatar.getAvatarGenreBadgeImg(),
+                avatar.getAvatarTag(),
+                avatarLine.getAvatarLineContent(),
+                avatar.getAvatarAcquiredImg(),
+                user.getUserNickname(),
+                userNovelCount,
+                memoCount,
+                avatars
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -40,11 +40,11 @@ public class UserService {
 
     public UserInfoGetResponse getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("aa"));
+                .orElseThrow(() -> new RuntimeException("해당하는 사용자가 없습니다."));
 
         Long userRepresentativeAvatarId = user.getUserRepAvatarId();
         Avatar avatar = avatarRepository.findById(userRepresentativeAvatarId)
-                .orElseThrow(() -> new RuntimeException("aa"));
+                .orElseThrow(() -> new RuntimeException("해당하는 대표 아바타가 없습니다."));
 
         List<AvatarLine> avatarLines = avatarLineRepository.findByAvatarId(userRepresentativeAvatarId);
 

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -1,8 +1,17 @@
 package com.wss.websoso.user;
 
+import com.wss.websoso.avatar.Avatar;
+import com.wss.websoso.avatar.AvatarRepository;
+import com.wss.websoso.avatarLine.AvatarLine;
+import com.wss.websoso.avatarLine.AvatarLineRepository;
 import com.wss.websoso.config.jwt.JwtProvider;
 import com.wss.websoso.config.jwt.UserAuthentication;
+import com.wss.websoso.userAvatar.UserAvatarRepository;
+import com.wss.websoso.userNovel.UserAvatarsGetResponse;
+import com.wss.websoso.userNovel.UserNovelRepository;
 import jakarta.security.auth.message.AuthException;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,8 +21,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
+    public static final int TOTAL_AVATAR_LINES = 10;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final UserNovelRepository userNovelRepository;
+    private final AvatarRepository avatarRepository;
+    private final AvatarLineRepository avatarLineRepository;
+    private final UserAvatarRepository userAvatarRepository;
 
     public String login(String userNickname) throws AuthException {
         User user = userRepository.findByUserNickname(userNickname)
@@ -22,5 +36,37 @@ public class UserService {
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);
 
         return jwtProvider.generateToken(userAuthentication);
+    }
+
+    public UserInfoGetResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("aa"));
+
+        Long userRepresentativeAvatarId = user.getUserRepAvatarId();
+        Avatar avatar = avatarRepository.findById(userRepresentativeAvatarId)
+                .orElseThrow(() -> new RuntimeException("aa"));
+
+        List<AvatarLine> avatarLines = avatarLineRepository.findByAvatarId(userRepresentativeAvatarId);
+
+        long userNovelCount = userNovelRepository.countByUserId(userId);
+
+        long memoCount = user.getMemoCount();
+
+        List<Avatar> allAvatars = avatarRepository.findAll();
+        List<Long> ownAvatarIdList = userAvatarRepository.findAvatarIdByUserId(userId);
+        System.out.println(ownAvatarIdList);
+        List<UserAvatarsGetResponse> userAvatarList = new ArrayList<>();
+        for (Avatar a : allAvatars) {
+            if (ownAvatarIdList.contains(a.getAvatarId())) {
+                userAvatarList.add(
+                        new UserAvatarsGetResponse(a.getAvatarId(), a.getAvatarAcquiredImg()));
+            } else {
+                userAvatarList.add(
+                        new UserAvatarsGetResponse(a.getAvatarId(), a.getAvatarUnacquiredImg()));
+            }
+        }
+
+        return UserInfoGetResponse.of(user, avatar, userNovelCount,
+                avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES)), memoCount, userAvatarList);
     }
 }

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -47,23 +47,16 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("해당하는 대표 아바타가 없습니다."));
 
         List<AvatarLine> avatarLines = avatarLineRepository.findByAvatarId(userRepresentativeAvatarId);
-
         long userNovelCount = userNovelRepository.countByUserId(userId);
 
         long memoCount = user.getMemoCount();
 
         List<Avatar> allAvatars = avatarRepository.findAll();
         List<Long> ownAvatarIdList = userAvatarRepository.findAvatarIdByUserId(userId);
-        List<UserAvatarsGetResponse> userAvatarList = new ArrayList<>();
-        for (Avatar a : allAvatars) {
-            if (ownAvatarIdList.contains(a.getAvatarId())) {
-                userAvatarList.add(
-                        new UserAvatarsGetResponse(a.getAvatarId(), a.getAvatarAcquiredImg()));
-            } else {
-                userAvatarList.add(
-                        new UserAvatarsGetResponse(a.getAvatarId(), a.getAvatarUnacquiredImg()));
-            }
-        }
+        List<UserAvatarsGetResponse> userAvatarList = new ArrayList<>(allAvatars.stream()
+                .map(eachAvatar -> new UserAvatarsGetResponse(eachAvatar.getAvatarId(),
+                        ownAvatarIdList.contains(eachAvatar.getAvatarId()) ?
+                                eachAvatar.getAvatarAcquiredImg() : eachAvatar.getAvatarUnacquiredImg())).toList());
 
         return UserInfoGetResponse.of(user, avatar, userNovelCount,
                 avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES)), memoCount, userAvatarList);

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -54,7 +54,6 @@ public class UserService {
 
         List<Avatar> allAvatars = avatarRepository.findAll();
         List<Long> ownAvatarIdList = userAvatarRepository.findAvatarIdByUserId(userId);
-        System.out.println(ownAvatarIdList);
         List<UserAvatarsGetResponse> userAvatarList = new ArrayList<>();
         for (Avatar a : allAvatars) {
             if (ownAvatarIdList.contains(a.getAvatarId())) {

--- a/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
+++ b/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
@@ -1,0 +1,11 @@
+package com.wss.websoso.userAvatar;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface UserAvatarRepository extends JpaRepository<UserAvatar, Long> {
+
+    @Query(value = "SELECT ua.avatar.avatarId FROM UserAvatar ua WHERE ua.user.userId = ?1")
+    List<Long> findAvatarIdByUserId(Long userId);
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserAvatarsGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserAvatarsGetResponse.java
@@ -1,0 +1,7 @@
+package com.wss.websoso.userNovel;
+
+public record UserAvatarsGetResponse(
+        Long avatarId,
+        String avatarImg
+) {
+}

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelRepository.java
@@ -2,13 +2,12 @@ package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.user.User;
+import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserNovelRepository extends JpaRepository<UserNovel, Long> {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#54 -> dev
- close #54

## Key Changes
<!-- 최대한 자세히 -->
- `UserService`
  - AvatarLine 테이블에서 특정 avatar의 대사들이 미리 저장되어 있고, 해당 대사들 중에서 랜덤으로 출력해줘야하는 로직을 현재 시간을 한 캐릭터의 총 대사 개수로 나눈 나머지의 값을 이용했습니다. 해당 값을 인덱스로 사용.
: `avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES))` 
  - 획득 혹은 미획득에 따라 내려주어야 하는 값이 다릅니다. 분기로 처리하였습니다.
   : `if (ownAvatarIdList.contains(a.getAvatarId())`

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
로직이 복잡하지는 않지만 처리하기 위한 오버헤드가 좀 큰 것 같아서 고민입니다. 리팩토링 요소가 될 것 같습니다.
