### PR TITLE
[FIX] platform 안의 user_novel_id nullable=true로 변경

### DIFF
--- a/src/main/java/com/wss/websoso/platform/Platform.java
+++ b/src/main/java/com/wss/websoso/platform/Platform.java
@@ -38,7 +38,7 @@ public class Platform {
     private Novel novel;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_novel_id", nullable = false)
+    @JoinColumn(name = "user_novel_id")
     private UserNovel userNovel;
 
     @Builder


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#60 -> dev
- close #60 

## Key Changes
<!-- 최대한 자세히 -->
- 크롤링 된 웹소설들의 url도 platform 테이블 안에 저장되게 되는데, 만약 `user_novel_id`가 nullable=false라면 어떠한 작품이 크롤링은 되어 있지만 아무도 서재에 등록하지 않았을 시에 크롤링된 웹소설의 url도 저장해 둘 곳이 없어지게 됩니다. 처음에 짰던 erd에는 nullable이 알맞게 들어가있었는데, 코드를 짜면서 잘못 붙었던 것 같아 수정합니다!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 혹시 오늘 생각해보니까 `nullable=false`가 맞는 것 같다! 리뷰로 남겨주세요

## References
<!-- 참고한 자료-->
X