### PR TITLE
[FEAT] 대표 아바타 조회 API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/avatar/AvatarController.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarController.java
@@ -1,0 +1,24 @@
+package com.wss.websoso.avatar;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class AvatarController {
+
+    private final AvatarService avatarService;
+
+    @GetMapping("/rep-avatar")
+    public ResponseEntity<UserRepAvatarGetResponse> getRepAvatar(Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(avatarService.getRepAvatar(userId));
+    }
+}

--- a/src/main/java/com/wss/websoso/avatar/AvatarRepository.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarRepository.java
@@ -1,0 +1,8 @@
+package com.wss.websoso.avatar;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+}

--- a/src/main/java/com/wss/websoso/avatar/AvatarService.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarService.java
@@ -1,0 +1,40 @@
+package com.wss.websoso.avatar;
+
+import com.wss.websoso.avatarLine.AvatarLine;
+import com.wss.websoso.avatarLine.AvatarLineRepository;
+import com.wss.websoso.user.User;
+import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userAvatar.UserAvatarRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+
+    private static final int TOTAL_AVATAR_LINES = 10;
+    private final AvatarRepository avatarRepository;
+    private final UserRepository userRepository;
+    private final UserAvatarRepository userAvatarRepository;
+    private final AvatarLineRepository avatarLineRepository;
+
+    public UserRepAvatarGetResponse getRepAvatar(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+
+        Long userRepAvatarId = user.getUserRepAvatarId();
+
+        Avatar avatar = avatarRepository.findById(userRepAvatarId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 아바타가 없습니다."));
+
+        userAvatarRepository.findByUserAndAvatar(user, avatar)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 해당 아바타를 가지고 있지 않습니다."));
+
+        List<AvatarLine> avatarLines = avatarLineRepository.findByAvatar(avatar);
+        String randomAvatarLine = avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES)).getAvatarLineContent();
+
+        return UserRepAvatarGetResponse.of(avatar, randomAvatarLine, user.getUserNickname());
+    }
+}

--- a/src/main/java/com/wss/websoso/avatar/UserRepAvatarGetResponse.java
+++ b/src/main/java/com/wss/websoso/avatar/UserRepAvatarGetResponse.java
@@ -3,14 +3,12 @@ package com.wss.websoso.avatar;
 public record UserRepAvatarGetResponse(
         String avatarTag,
         String avatarLine,
-        String avatarImg,
         String userNickname
 ) {
     public static UserRepAvatarGetResponse of(Avatar avatar, String avatarLine, String userNickname) {
         return new UserRepAvatarGetResponse(
                 avatar.getAvatarTag(),
                 avatarLine,
-                avatar.getAvatarAcquiredImg(),
                 userNickname
         );
     }

--- a/src/main/java/com/wss/websoso/avatar/UserRepAvatarGetResponse.java
+++ b/src/main/java/com/wss/websoso/avatar/UserRepAvatarGetResponse.java
@@ -1,0 +1,17 @@
+package com.wss.websoso.avatar;
+
+public record UserRepAvatarGetResponse(
+        String avatarTag,
+        String avatarLine,
+        String avatarImg,
+        String userNickname
+) {
+    public static UserRepAvatarGetResponse of(Avatar avatar, String avatarLine, String userNickname) {
+        return new UserRepAvatarGetResponse(
+                avatar.getAvatarTag(),
+                avatarLine,
+                avatar.getAvatarAcquiredImg(),
+                userNickname
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/avatarLine/AvatarLineRepository.java
+++ b/src/main/java/com/wss/websoso/avatarLine/AvatarLineRepository.java
@@ -1,0 +1,13 @@
+package com.wss.websoso.avatarLine;
+
+import com.wss.websoso.avatar.Avatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AvatarLineRepository extends JpaRepository<AvatarLine, Long> {
+
+    List<AvatarLine> findByAvatar(Avatar avatar);
+}

--- a/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
+++ b/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
@@ -1,0 +1,12 @@
+package com.wss.websoso.userAvatar;
+
+import com.wss.websoso.avatar.Avatar;
+import com.wss.websoso.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAvatarRepository extends JpaRepository<UserAvatar, Long> {
+
+    Optional<UserAvatar> findByUserAndAvatar(User user, Avatar avatar);
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#58 -> dev
- close #58

## Key Changes
<!-- 최대한 자세히 -->
로그인 한 유저의 userId와 userRepAvatarId를 이용하여 유저의 대표 아바타를 찾고, 해당 아바타와 연결된 avatarLine을 조회해, 그 중 랜덤한 한 개의 avatarLine, avatarTag, avatarImg, userNickname 을 반환하는 API입니다.
아바타와 연결된 avatarLine 리스트 중 랜덤한 한 개의 값을 고르는 로직은 다음과 같습니다.
```java
private static final int TOTAL_AVATAR_LINES = 10;
String randomAvatarLine = avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES)).getAvatarLineContent();
``` 
TOTAL_AVATAR_LINES는 한 아바타가 가지고 있는 문구의 개수입니다. 
성능을 고려하여, 문구의 개수를 상수로 선언해, 랜덤 문구를 가져오는 기능에 문구의 개수를 세는 로직은 사용되지 않습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X