### PR TITLE
[FEAT] 메모 작성 API 아바타 해금 응답 추가 완료

### DIFF
--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -1,5 +1,7 @@
 package com.wss.websoso.memo;
 
+import java.security.Principal;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.security.Principal;
-import java.util.Map;
-
 @RestController
 @RequestMapping("/memos")
 @RequiredArgsConstructor
@@ -26,26 +24,13 @@ public class MemoController {
 
     // 생성
     @PostMapping("{userNovelId}")
-    public ResponseEntity<Map<String, String>> createMemo(
+    public ResponseEntity<MemoCreateResponse> createMemo(
             @PathVariable Long userNovelId,
             @RequestBody MemoCreateRequest request,
             Principal principal
     ) {
-        try {
-            URI location = URI.create(memoService.create(Long.valueOf(principal.getName()), userNovelId, request));
-            return ResponseEntity.created(location).build();
-        } catch (IllegalArgumentException e) {
-            if ("내 서재의 작품이 아닙니다.".equals(e.getMessage())) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                        .body(Map.of("message", "내 서재의 작품이 아닙니다."));
-            } else if ("memoContent의 최대 길이를 초과했습니다.".equals(e.getMessage())) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body(Map.of("message", "memoContent의 최대 길이를 초과했습니다."));
-            } else {
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body(Map.of("message", "예상치 못한 오류가 발생했습니다."));
-            }
-        }
+        MemoCreateResponse response = memoService.create(Long.valueOf(principal.getName()), userNovelId, request);
+        return ResponseEntity.ok(response);
     }
 
     // 서재 메모 전체 조회

--- a/src/main/java/com/wss/websoso/memo/MemoCreateResponse.java
+++ b/src/main/java/com/wss/websoso/memo/MemoCreateResponse.java
@@ -1,11 +1,11 @@
 package com.wss.websoso.memo;
 
 public record MemoCreateResponse(
-        Boolean avatarUnlocked
+        Boolean isAvatarUnlocked
 ) {
-    public static MemoCreateResponse of(Boolean avatarUnlocked) {
+    public static MemoCreateResponse of(Boolean isAvatarUnlocked) {
         return new MemoCreateResponse(
-                avatarUnlocked
+                isAvatarUnlocked
         );
     }
 }

--- a/src/main/java/com/wss/websoso/memo/MemoCreateResponse.java
+++ b/src/main/java/com/wss/websoso/memo/MemoCreateResponse.java
@@ -1,0 +1,11 @@
+package com.wss.websoso.memo;
+
+public record MemoCreateResponse(
+        Boolean avatarUnlocked
+) {
+    public static MemoCreateResponse of(Boolean avatarUnlocked) {
+        return new MemoCreateResponse(
+                avatarUnlocked
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/memo/MemoRepository.java
+++ b/src/main/java/com/wss/websoso/memo/MemoRepository.java
@@ -1,6 +1,5 @@
 package com.wss.websoso.memo;
 
-import com.wss.websoso.userNovel.UserNovel;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -10,8 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
-    List<Memo> findAllByUserNovelIn(List<UserNovel> userNovels);
-
     // NEWEST
     @Query(value = "SELECT m FROM Memo m WHERE "
             + "m.userNovel.user.userId = ?1 AND "
@@ -28,7 +25,7 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
     @Query(value = "SELECT COUNT(m) FROM Memo m WHERE "
             + "m.userNovel.user.userId = ?1")
     long countByUserId(Long userId);
-  
-  @Query(value = "SELECT m FROM Memo m WHERE m.userNovel.userNovelId = ?1")
+
+    @Query(value = "SELECT m FROM Memo m WHERE m.userNovel.userNovelId = ?1")
     List<Memo> findByUserNovelId(Long userNovelId);
 }

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -47,12 +47,12 @@ public class MemoService {
 
         user.updateUserWrittenMemoCount();
 
-        Boolean avatarUnlocked = false;
+        Boolean isAvatarUnlocked = false;
         if (user.getUserWrittenMemoCount() == 1 || user.getUserWrittenMemoCount() == 10) {
-            avatarUnlocked = true;
+            isAvatarUnlocked = true;
         }
 
-        return MemoCreateResponse.of(avatarUnlocked);
+        return MemoCreateResponse.of(isAvatarUnlocked);
     }
 
     public MemosGetResponse getMemos(Long userId, Long lastMemoId, int size, String sortType) {

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -5,14 +5,13 @@ import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +25,7 @@ public class MemoService {
     private final UserNovelRepository userNovelRepository;
 
     @Transactional
-    public String create(Long userId, Long userNovelId, MemoCreateRequest request) {
+    public MemoCreateResponse create(Long userId, Long userNovelId, MemoCreateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
 
@@ -41,11 +40,19 @@ public class MemoService {
             throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
         }
 
-        Memo memo = memoRepository.save(Memo.builder()
+        memoRepository.save(Memo.builder()
                 .memoContent(request.memoContent())
                 .userNovel(userNovel)
                 .build());
-        return memo.getMemoId().toString();
+
+        user.updateUserWrittenMemoCount();
+
+        Boolean avatarUnlocked = false;
+        if (user.getUserWrittenMemoCount() == 1 || user.getUserWrittenMemoCount() == 10) {
+            avatarUnlocked = true;
+        }
+
+        return MemoCreateResponse.of(avatarUnlocked);
     }
 
     public MemosGetResponse getMemos(Long userId, Long lastMemoId, int size, String sortType) {

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -30,7 +30,6 @@ public class User {
     private Long userRepAvatarId;
 
     @Column(name = "user_written_memo_count", columnDefinition = "bigint default 0", nullable = false)
-
     private Long userWrittenMemoCount;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/wss/websoso/user/User.java
+++ b/src/main/java/com/wss/websoso/user/User.java
@@ -29,6 +29,13 @@ public class User {
     @Column(name = "user_rep_avatar_id", nullable = false)
     private Long userRepAvatarId;
 
+    @Column(name = "user_written_memo_count", nullable = false)
+    private Long userWrittenMemoCount;
+
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserAvatar> userAvatars;
+
+    public void updateUserWrittenMemoCount() {
+        this.userWrittenMemoCount++;
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#66 -> dev
- close #66 

## Key Changes
<!-- 최대한 자세히 -->
- 메모를 1개 혹은 10개 작성 시 새로운 아바타를 해금하도록 코드를 추가하였습니다.
- 해금 조건 충족 여부를 response로 내려줍니다.
- avatarUnlocked는 default false로, 해금 시, 즉 첫번째와 열번째 메모 작성 시에만 true로 응답합니다.
- 이 때에 현재 존재하는 메모 개수로 해금되는 것이 아니라, 삭제된 메모들까지 포함하여 개수가 측정됩니다.
  ```
  {
      "avatarUnlocked": true
  }
  ```

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X