### PR TITLE
[FEAT] 아바타 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/wss/websoso/avatar/AvatarController.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarController.java
@@ -3,9 +3,10 @@ package com.wss.websoso.avatar;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
@@ -32,5 +33,13 @@ public class AvatarController {
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/avatars/{avatarId}")
+    public ResponseEntity<AvatarGetResponse> getAvatar(@PathVariable Long avatarId, Principal principal) {
+        Long userId = Long.valueOf(principal.getName());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(avatarService.getAvatar(userId, avatarId));
     }
 }

--- a/src/main/java/com/wss/websoso/avatar/AvatarGetResponse.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarGetResponse.java
@@ -1,0 +1,17 @@
+package com.wss.websoso.avatar;
+
+public record AvatarGetResponse(
+        String avatarTag,
+        String avatarGenreBadgeImg,
+        String avatarMent,
+        String avatarCondition
+) {
+    public static AvatarGetResponse of(Avatar avatar, String avatarMent, String avatarCondition) {
+        return new AvatarGetResponse(
+                avatar.getAvatarTag(),
+                avatar.getAvatarGenreBadgeImg(),
+                avatarMent,
+                avatarCondition
+        );
+    }
+}

--- a/src/main/java/com/wss/websoso/avatar/AvatarService.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarService.java
@@ -4,12 +4,14 @@ import com.wss.websoso.avatarLine.AvatarLine;
 import com.wss.websoso.avatarLine.AvatarLineRepository;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userAvatar.UserAvatar;
 import com.wss.websoso.userAvatar.UserAvatarRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +23,7 @@ public class AvatarService {
     private final AvatarLineRepository avatarLineRepository;
     private final UserRepository userRepository;
     private final AvatarRepository avatarRepository;
-  
+
     public UserRepAvatarGetResponse getRepAvatar(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
@@ -55,5 +57,20 @@ public class AvatarService {
         }
 
         user.updateUserRepAvatar(avatarId);
+    }
+
+    public AvatarGetResponse getAvatar(Long userId, Long avatarId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
+        Avatar avatar = avatarRepository.findById(avatarId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 아바타가 없습니다."));
+
+        Optional<UserAvatar> userAvatar = userAvatarRepository.findByUserAndAvatar(user, avatar);
+
+        if (userAvatar.isEmpty()) {
+            return AvatarGetResponse.of(avatar, avatar.getAvatarUnacquiredMent(), avatar.getAvatarUnacquiredCondition());
+        }
+
+        return AvatarGetResponse.of(avatar, avatar.getAvatarAcquiredMent(), avatar.getAvatarAcquiredCondition());
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#71 -> dev
- close #71

## Key Changes
<!-- 최대한 자세히 -->
avatarId로 아바타의 정보를 조회하는 API입니다.
API 호출 시 현재 로그인 한 유저의 정보를 함께 받아 유저가 보유한 아바타인지 미보유한 아바타인지 판단하여 알맞는 값을 반환합니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X