### PR TITLE
[RENAME] 소소's pick API DTO 네이밍 변경

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/SosoPicksGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/SosoPicksGetResponse.java
@@ -2,7 +2,7 @@ package com.wss.websoso.userNovel;
 
 import java.util.List;
 
-public record sosoPicksGetResponse(
+public record SosoPicksGetResponse(
         List<sosoPickGetResponse> sosoPickNovelList
 ) {
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -1,9 +1,6 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
-import java.net.URI;
-import java.security.Principal;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +13,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -71,13 +72,12 @@ public class UserNovelController {
     }
 
     @GetMapping("/soso-picks")
-    public ResponseEntity<sosoPicksGetResponse> getSosoPicks() {
+    public ResponseEntity<SosoPicksGetResponse> getSosoPicks() {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(userNovelService.getSosoPicks());
-
     }
-  
+
     @DeleteMapping("/{userNovelId}")
     public ResponseEntity<Void> deleteUserNovel(@PathVariable Long userNovelId,
                                                 Principal principal) {

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -134,13 +134,13 @@ public class UserNovelService {
         return UserNovelMemoAndInfoGetResponse.of(memos, userNovel, platforms, genreBadge);
     }
 
-    public sosoPicksGetResponse getSosoPicks() {
+    public SosoPicksGetResponse getSosoPicks() {
         Long lastUserNovelId;
         try {
             lastUserNovelId = userNovelRepository.findByMaxUserNovelId()
                     .orElseThrow(() -> new RuntimeException("유저가 등록한 서재 작품이 없습니다."));
         } catch (Exception e) {
-            return new sosoPicksGetResponse(new ArrayList<>());
+            return new SosoPicksGetResponse(new ArrayList<>());
         }
         List<Novel> recentNovels = new ArrayList<>();
         int count = 0;
@@ -164,7 +164,7 @@ public class UserNovelService {
                 .map(novel -> sosoPickGetResponse.of(novel, userNovelRepository.countUserNovelsByNovelId(novel.getNovelId())))
                 .toList();
 
-        return new sosoPicksGetResponse(sosoPicks);
+        return new SosoPicksGetResponse(sosoPicks);
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- refactor/#73 -> dev
- close #73

## Key Changes
<!-- 최대한 자세히 -->
기존 사용하던 Response DTO명인 `sosoPickGetResponse`가 첫글자가 대문자로 시작해야 하는 카멜표기법을 위반해, DTO명을 `SosoPickGetResponse`로 변경했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X