### PR TITLE
[FIX] 서재 작품 메모&정보 조회 결과를 최신순으로 정렬하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/wss/websoso/memo/MemoRepository.java
+++ b/src/main/java/com/wss/websoso/memo/MemoRepository.java
@@ -1,11 +1,12 @@
 package com.wss.websoso.memo;
 
-import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
@@ -26,6 +27,6 @@ public interface MemoRepository extends JpaRepository<Memo, Long> {
             + "m.userNovel.user.userId = ?1")
     long countByUserId(Long userId);
 
-    @Query(value = "SELECT m FROM Memo m WHERE m.userNovel.userNovelId = ?1")
-    List<Memo> findByUserNovelId(Long userNovelId);
+    @Query(value = "SELECT m FROM Memo m WHERE m.userNovel.userNovelId = ?1 ORDER BY m.memoId Desc")
+    List<Memo> findByUserNovelIdDesc(Long userNovelId);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -17,15 +17,16 @@ import com.wss.websoso.userNovel.dto.UserNovelCreateRequest;
 import com.wss.websoso.userNovel.dto.UserNovelMemoAndInfoGetResponse;
 import com.wss.websoso.userNovel.dto.UserNovelUpdateRequest;
 import com.wss.websoso.userNovel.dto.UserNovelsResponse;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -131,7 +132,7 @@ public class UserNovelService {
             throw new RuntimeException("잘못된 접근입니다.(인가X)");
         }
 
-        List<Memo> memos = memoRepository.findByUserNovelId(userNovelId);
+        List<Memo> memos = memoRepository.findByUserNovelIdDesc(userNovelId);
         List<Platform> platforms = platformRepository.findByUserNovelId(userNovelId);
         UserNovel userNovel = userNovelRepository.findByUserNovelId(userNovelId);
         GenreBadge genreBadge = genreBadgeRepository.findByGenreBadgeName(userNovel.getUserNovelGenre());


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#78 -> dev
- close #78

## Key Changes
<!-- 최대한 자세히 -->
서재 작품 메모&정보 조회 API 반환값이 DB에 저장된 순으로 반환되는 오류가 있어, 기능 요구사항에 알맞게 최신순으로 정렬하여 반환되도록 API를 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X