### PR TITLE
[FIX] 메모 작성 API (특정 조건 달성 시 아바타 해금 및 획득 로직 추가)

### DIFF
--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemoService {
 
-    public static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
 
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -7,6 +7,7 @@ import com.wss.websoso.memo.dto.MemoUpdateRequest;
 import com.wss.websoso.memo.dto.MemosGetResponse;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
+import com.wss.websoso.userAvatar.UserAvatarRepository;
 import com.wss.websoso.userNovel.UserNovel;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -28,6 +29,7 @@ public class MemoService {
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;
     private final UserNovelRepository userNovelRepository;
+    private final UserAvatarRepository userAvatarRepository;
 
     @Transactional
     public MemoCreateResponse createMemo(Long userId, Long userNovelId, MemoCreateRequest memoCreateRequest) {
@@ -51,8 +53,14 @@ public class MemoService {
                 .build());
 
         user.updateUserWrittenMemoCount();
-        boolean isAvatarUnlocked = user.getUserWrittenMemoCount() == 1 || user.getUserWrittenMemoCount() == 10;
-
+        Long userWrittenMemoCount = user.getUserWrittenMemoCount();
+        if (userWrittenMemoCount == 1L) {
+            userAvatarRepository.createUserAvatar(userId, 2L);
+        }
+        if (userWrittenMemoCount == 10L) {
+            userAvatarRepository.createUserAvatar(userId, 3L);
+        }
+        boolean isAvatarUnlocked = userWrittenMemoCount == 1L || userWrittenMemoCount == 10L;
         return MemoCreateResponse.of(isAvatarUnlocked);
     }
 

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -25,6 +25,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemoService {
 
     private static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final long SECOND_AVATAR_UNLOCK_CONDITION_MEMO_COUNT = 1L;
+    private static final long THIRD_AVATAR_UNLOCK_CONDITION_MEMO_COUNT = 10L;
+    private static final long SECOND_AVATAR_ID = 2L;
+    private static final long THIRD_AVATAR_ID = 3L;
+    private static final long MAX_MEMO_CONTENT_LENGTH = 2000L;
 
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;
@@ -43,7 +48,7 @@ public class MemoService {
             throw new IllegalArgumentException("내 서재의 작품이 아닙니다.");
         }
 
-        if (memoCreateRequest.memoContent().length() > 2000) {
+        if (memoCreateRequest.memoContent().length() > MAX_MEMO_CONTENT_LENGTH) {
             throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
         }
 
@@ -54,13 +59,14 @@ public class MemoService {
 
         user.updateUserWrittenMemoCount();
         Long userWrittenMemoCount = user.getUserWrittenMemoCount();
-        if (userWrittenMemoCount == 1L) {
-            userAvatarRepository.createUserAvatar(userId, 2L);
+        if (userWrittenMemoCount == SECOND_AVATAR_UNLOCK_CONDITION_MEMO_COUNT) {
+            userAvatarRepository.createUserAvatar(userId, SECOND_AVATAR_ID);
         }
-        if (userWrittenMemoCount == 10L) {
-            userAvatarRepository.createUserAvatar(userId, 3L);
+        if (userWrittenMemoCount == THIRD_AVATAR_UNLOCK_CONDITION_MEMO_COUNT) {
+            userAvatarRepository.createUserAvatar(userId, THIRD_AVATAR_ID);
         }
-        boolean isAvatarUnlocked = userWrittenMemoCount == 1L || userWrittenMemoCount == 10L;
+        boolean isAvatarUnlocked = userWrittenMemoCount == SECOND_AVATAR_UNLOCK_CONDITION_MEMO_COUNT
+                || userWrittenMemoCount == THIRD_AVATAR_UNLOCK_CONDITION_MEMO_COUNT;
         return MemoCreateResponse.of(isAvatarUnlocked);
     }
 
@@ -115,7 +121,7 @@ public class MemoService {
             throw new IllegalArgumentException("사용자의 메모가 아닙니다.");
         }
 
-        if (request.memoContent().length() > 2000) {
+        if (request.memoContent().length() > MAX_MEMO_CONTENT_LENGTH) {
             throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
         }
 

--- a/src/main/java/com/wss/websoso/memo/MemoService.java
+++ b/src/main/java/com/wss/websoso/memo/MemoService.java
@@ -30,7 +30,7 @@ public class MemoService {
     private final UserNovelRepository userNovelRepository;
 
     @Transactional
-    public MemoCreateResponse create(Long userId, Long userNovelId, MemoCreateRequest request) {
+    public MemoCreateResponse createMemo(Long userId, Long userNovelId, MemoCreateRequest memoCreateRequest) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 사용자가 없습니다."));
 
@@ -41,17 +41,16 @@ public class MemoService {
             throw new IllegalArgumentException("내 서재의 작품이 아닙니다.");
         }
 
-        if (request.memoContent().length() > 2000) {
+        if (memoCreateRequest.memoContent().length() > 2000) {
             throw new IllegalArgumentException("memoContent의 최대 길이를 초과했습니다.");
         }
 
         memoRepository.save(Memo.builder()
-                .memoContent(request.memoContent())
+                .memoContent(memoCreateRequest.memoContent())
                 .userNovel(userNovel)
                 .build());
 
         user.updateUserWrittenMemoCount();
-
         boolean isAvatarUnlocked = user.getUserWrittenMemoCount() == 1 || user.getUserWrittenMemoCount() == 10;
 
         return MemoCreateResponse.of(isAvatarUnlocked);

--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -7,8 +7,8 @@ import com.wss.websoso.platform.dto.PlatformGetResponse;
 import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userNovel.UserNovel;
-import com.wss.websoso.userNovel.dto.UserNovelGetResponse;
 import com.wss.websoso.userNovel.UserNovelRepository;
+import com.wss.websoso.userNovel.dto.UserNovelGetResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class NovelService {
 
-    public static final int DEFAULT_PAGE_NUMBER = 0;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
     private final NovelRepository novelRepository;
     private final UserRepository userRepository;
     private final UserNovelRepository userNovelRepository;

--- a/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
+++ b/src/main/java/com/wss/websoso/userAvatar/UserAvatarRepository.java
@@ -2,12 +2,13 @@ package com.wss.websoso.userAvatar;
 
 import com.wss.websoso.avatar.Avatar;
 import com.wss.websoso.user.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface UserAvatarRepository extends JpaRepository<UserAvatar, Long> {
@@ -16,4 +17,9 @@ public interface UserAvatarRepository extends JpaRepository<UserAvatar, Long> {
     List<Long> findAvatarIdByUserId(Long userId);
 
     Optional<UserAvatar> findByUserAndAvatar(User user, Avatar avatar);
+
+    @Transactional
+    @Modifying
+    @Query(value = "INSERT INTO user_avatar (user_id, avatar_id) VALUES (?1 , ?2)", nativeQuery = true)
+    void createUserAvatar(Long userId, Long avatarId);
 }

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -1,9 +1,9 @@
 package com.wss.websoso.userNovel;
 
 import com.wss.websoso.config.ReadStatus;
+import com.wss.websoso.memo.MemoService;
 import com.wss.websoso.memo.dto.MemoCreateRequest;
 import com.wss.websoso.memo.dto.MemoCreateResponse;
-import com.wss.websoso.memo.MemoService;
 import com.wss.websoso.userNovel.dto.SosoPicksGetResponse;
 import com.wss.websoso.userNovel.dto.UserNovelCreateRequest;
 import com.wss.websoso.userNovel.dto.UserNovelMemoAndInfoGetResponse;
@@ -50,11 +50,14 @@ public class UserNovelController {
     @PostMapping("/{userNovelId}/memo")
     public ResponseEntity<MemoCreateResponse> createMemo(
             @PathVariable Long userNovelId,
-            @RequestBody MemoCreateRequest request,
+            @RequestBody MemoCreateRequest memoCreateRequest,
             Principal principal
     ) {
-        MemoCreateResponse response = memoService.create(Long.valueOf(principal.getName()), userNovelId, request);
-        return ResponseEntity.ok(response);
+        Long userId = Long.valueOf(principal.getName());
+        MemoCreateResponse memoCreateResponse = memoService.createMemo(userId, userNovelId, memoCreateRequest);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(memoCreateResponse);
     }
 
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#77 -> dev
- close #77

## Key Changes
<!-- 최대한 자세히 -->
- 아바타 해금 조건(메모 1개, 10개 작성) 달성 시, 아바타 획득 로직 추가 
- threshold나 condition 등을 조건문에서 하드코딩 -> 상수로 변경
- 일부 상수 접근 제어자 변경 (public -> private)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
아바타 획득 로직 추가하면서 새로운 내용을 알게되었습니다. 
`@Query`로 JPQL을 사용하는 방식과 JPA method를 이용하는 방식의 동작 방식의 차이가 있습니다.
영속성 컨텍스트에서 조회를 하는지, DB에서 조회를 하는지가 조금 달랐는데, 이해하지 않고 JPQL 사용을 지양하는 것이 좋을 것 같습니다.
