### PR TITLE
[FIX] 서재 작품 메모&정보 조회 API 반환값 추가

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/dto/UserNovelMemoAndInfoGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/dto/UserNovelMemoAndInfoGetResponse.java
@@ -5,11 +5,15 @@ import com.wss.websoso.genreBadge.GenreBadge;
 import com.wss.websoso.memo.Memo;
 import com.wss.websoso.platform.Platform;
 import com.wss.websoso.userNovel.UserNovel;
+
 import java.util.List;
 
 public record UserNovelMemoAndInfoGetResponse(
         List<UserNovelMemosGetResponse> memos,
         float userNovelRating,
+        String userNovelTitle,
+        String userNovelImg,
+        String userNovelAuthor,
         ReadStatus userNovelReadStatus,
         String userNovelReadStartDate,
         String userNovelReadEndDate,
@@ -37,6 +41,9 @@ public record UserNovelMemoAndInfoGetResponse(
         return new UserNovelMemoAndInfoGetResponse(
                 memoList,
                 userNovel.getUserNovelRating(),
+                userNovel.getUserNovelTitle(),
+                userNovel.getUserNovelImg(),
+                userNovel.getUserNovelAuthor(),
                 userNovel.getUserNovelReadStatus(),
                 userNovel.getUserNovelReadStartDate(),
                 userNovel.getUserNovelReadEndDate(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#85 -> dev
- close #85

## Key Changes
<!-- 최대한 자세히 -->
기존 서재 뷰에 존재하는 작품의 제목, 이미지, 작가 정보를 저장해두었다가 다음 뷰에서 정보를 조회하는 API인 서재 작품 메모&정보 조회 API에서 사용하는 방식이었지만, 클라이언트 요청으로 인해 반환값에 작품 제목, 이미지, 작가를 추가해서 반환하도록 수정

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X