### PR TITLE
[FIX] 작품 등록(GET) API Response DTO 필드명 변경

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -51,11 +51,17 @@ public class NovelService {
                     .orElseThrow(() -> new IllegalArgumentException("해당하는 등록된 작품이 없습니다."));
 
             return new NovelDetailGetResponse(
+                    null,
                     userNovel.getUserNovelId(),
+                    null,
                     userNovel.getUserNovelTitle(),
+                    null,
                     userNovel.getUserNovelAuthor(),
+                    null,
                     userNovel.getUserNovelGenre(),
+                    null,
                     userNovel.getUserNovelImg(),
+                    null,
                     userNovel.getUserNovelDescription(),
                     userNovel.getUserNovelRating(),
                     userNovel.getUserNovelReadStatus(),
@@ -71,11 +77,17 @@ public class NovelService {
         } catch (IllegalArgumentException e) {
             return new NovelDetailGetResponse(
                     novel.getNovelId(),
+                    null,
                     novel.getNovelTitle(),
+                    null,
                     novel.getNovelAuthor(),
+                    null,
                     novel.getNovelGenre(),
+                    null,
                     novel.getNovelImg(),
+                    null,
                     novel.getNovelDescription(),
+                    null,
                     null,
                     null,
                     null,

--- a/src/main/java/com/wss/websoso/novel/dto/NovelDetailGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/dto/NovelDetailGetResponse.java
@@ -7,12 +7,30 @@ import com.wss.websoso.platform.dto.PlatformGetResponse;
 import java.util.List;
 
 public record NovelDetailGetResponse(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         Long novelId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        Long userNovelId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         String novelTitle,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String userNovelTitle,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         String novelAuthor,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String userNovelAuthor,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         String novelGenre,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String userNovelGenre,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         String novelImg,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String userNovelImg,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         String novelDescription,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String userNovelDescription,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Float userNovelRating,
         @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#91 -> dev
- close #91

## Key Changes
<!-- 최대한 자세히 -->
작품 등록(GET) API Response가 novel을 조회했을 때는 novel 필드명으로, userNovel을 조회했을 때는 userNovel 필드명으로 반환해야 하지만, 모두 novel 필드명으로 반환이 되는 오류가 발생하여 DTO의 필드명을 상황에 맞게 내려줄 수 있도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X