### PR TITLE
[FIX] 작품 정보 조회(단건) API 반환값 수정

### DIFF
--- a/src/main/java/com/wss/websoso/novel/NovelService.java
+++ b/src/main/java/com/wss/websoso/novel/NovelService.java
@@ -50,7 +50,7 @@ public class NovelService {
             UserNovel userNovel = userNovelRepository.findByUserAndNovelId(user, novelId)
                     .orElseThrow(() -> new IllegalArgumentException("해당하는 등록된 작품이 없습니다."));
 
-            return new NovelDetailGetResponse(
+            NovelDetailGetResponse novelDetailGetResponse = new NovelDetailGetResponse(
                     null,
                     userNovel.getUserNovelId(),
                     null,
@@ -65,8 +65,6 @@ public class NovelService {
                     userNovel.getUserNovelDescription(),
                     userNovel.getUserNovelRating(),
                     userNovel.getUserNovelReadStatus(),
-                    userNovel.getUserNovelReadStartDate(),
-                    userNovel.getUserNovelReadEndDate(),
                     userNovel.getPlatforms().stream()
                             .map(platform -> new PlatformGetResponse(
                                     platform.getPlatformName(),
@@ -74,6 +72,8 @@ public class NovelService {
                             ))
                             .toList()
             );
+            novelDetailGetResponse.setUserNovelReadEndDate(userNovel.getUserNovelReadStartDate(), userNovel.getUserNovelReadEndDate());
+            return novelDetailGetResponse;
         } catch (IllegalArgumentException e) {
             return new NovelDetailGetResponse(
                     novel.getNovelId(),
@@ -87,8 +87,6 @@ public class NovelService {
                     novel.getNovelImg(),
                     null,
                     novel.getNovelDescription(),
-                    null,
-                    null,
                     null,
                     null,
                     null,

--- a/src/main/java/com/wss/websoso/novel/dto/NovelDetailGetResponse.java
+++ b/src/main/java/com/wss/websoso/novel/dto/NovelDetailGetResponse.java
@@ -1,44 +1,73 @@
 package com.wss.websoso.novel.dto;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.wss.websoso.config.ReadStatus;
 import com.wss.websoso.platform.dto.PlatformGetResponse;
+import lombok.Getter;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public record NovelDetailGetResponse(
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        Long novelId,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        Long userNovelId,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String novelTitle,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelTitle,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String novelAuthor,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelAuthor,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String novelGenre,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelGenre,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String novelImg,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelImg,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String novelDescription,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelDescription,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        Float userNovelRating,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        ReadStatus userNovelReadStatus,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelReadStartDate,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        String userNovelReadEndDate,
-        List<PlatformGetResponse> platforms
-) {
+@Getter
+public class NovelDetailGetResponse {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Long novelId;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Long userNovelId;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String novelTitle;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String userNovelTitle;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String novelAuthor;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String userNovelAuthor;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String novelGenre;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String userNovelGenre;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String novelImg;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String userNovelImg;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String novelDescription;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    String userNovelDescription;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Float userNovelRating;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    ReadStatus userNovelReadStatus;
+    List<PlatformGetResponse> platforms;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonUnwrapped
+    Map<String, String> userNovelReadDate;
+
+    public NovelDetailGetResponse(Long novelId, Long userNovelId, String novelTitle, String userNovelTitle, String novelAuthor, String userNovelAuthor, String novelGenre, String userNovelGenre, String novelImg, String userNovelImg, String novelDescription, String userNovelDescription, Float userNovelRating, ReadStatus userNovelReadStatus, List<PlatformGetResponse> platforms) {
+        this.novelId = novelId;
+        this.userNovelId = userNovelId;
+        this.novelTitle = novelTitle;
+        this.userNovelTitle = userNovelTitle;
+        this.novelAuthor = novelAuthor;
+        this.userNovelAuthor = userNovelAuthor;
+        this.novelGenre = novelGenre;
+        this.userNovelGenre = userNovelGenre;
+        this.novelImg = novelImg;
+        this.userNovelImg = userNovelImg;
+        this.novelDescription = novelDescription;
+        this.userNovelDescription = userNovelDescription;
+        this.userNovelRating = userNovelRating;
+        this.userNovelReadStatus = userNovelReadStatus;
+        this.platforms = platforms;
+    }
+
+    @JsonAnySetter
+    public void setUserNovelReadEndDate(String userNovelReadStartDate, String userNovelReadEndDate) {
+        userNovelReadDate = new HashMap<>();
+        userNovelReadDate.put("userNovelReadStartDate", userNovelReadStartDate);
+        userNovelReadDate.put("userNovelReadEndDate", userNovelReadEndDate);
+    }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#94 -> dev
- close #94

## Key Changes
<!-- 최대한 자세히 -->
기존 상황에 맞게 응답값을 다르게 내려주기 위해서 DTO를 두개 썼지만, 응답값의 일관화를 위해, `@JsonInclude(JsonInclude.Include.NON_NULL)` 속성을 통해 하나의 DTO로 반환값을 내려주도록 기능을 수정했었습니다. #82
하지만, 해당 기능 수정으로 인해 작품 정보 조회(단건) API 반환값 중 `userNovelReadStartDate`, `userNovelReadEndDate` 필드가 null일 경우 해당하는 필드가 응답값에 포함되지 않는 오류가 발생했습니다. (이미 서재에 등록한 작품일 경우 두 필드가 나와야함)
@JsonAnySetter를 통해 외부에서 set() 메서드를 통해 응답값을 추가해주는 방식을 사용하여 null일 경우에도 두 필드(`userNovelReadStartDate`, `userNovelReadEndDate`)를 나타내도록 설정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X