### PR TITLE
[FIX] 아바타 보유 여부 boolean 변수 추가하여 반환

### DIFF
--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -11,9 +11,9 @@ import com.wss.websoso.user.dto.UserLoginRequest;
 import com.wss.websoso.userAvatar.UserAvatarRepository;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import com.wss.websoso.userNovel.dto.UserAvatarsGetResponse;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,10 +71,13 @@ public class UserService {
 
         List<Avatar> allAvatars = avatarRepository.findAll();
         List<Long> ownAvatarIdList = userAvatarRepository.findAvatarIdByUserId(userId);
-        List<UserAvatarsGetResponse> userAvatarList = new ArrayList<>(allAvatars.stream()
-                .map(eachAvatar -> new UserAvatarsGetResponse(eachAvatar.getAvatarId(),
-                        ownAvatarIdList.contains(eachAvatar.getAvatarId()) ?
-                                eachAvatar.getAvatarAcquiredImg() : eachAvatar.getAvatarUnacquiredImg())).toList());
+        List<UserAvatarsGetResponse> userAvatarList = allAvatars.stream()
+                .map(eachAvatar -> {
+                    boolean hasAvatar = ownAvatarIdList.contains(eachAvatar.getAvatarId());
+                    return new UserAvatarsGetResponse(eachAvatar.getAvatarId(),
+                            hasAvatar ? eachAvatar.getAvatarAcquiredImg() : eachAvatar.getAvatarUnacquiredImg(),
+                            hasAvatar);
+                }).collect(Collectors.toList());
 
         return UserInfoGetResponse.of(user, avatar, userNovelCount,
                 avatarLines.get((int) (System.currentTimeMillis() % TOTAL_AVATAR_LINES)), memoCount, userAvatarList);

--- a/src/main/java/com/wss/websoso/userNovel/dto/UserAvatarsGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/dto/UserAvatarsGetResponse.java
@@ -2,6 +2,7 @@ package com.wss.websoso.userNovel.dto;
 
 public record UserAvatarsGetResponse(
         Long avatarId,
-        String avatarImg
+        String avatarImg,
+        boolean hasAvatar
 ) {
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#95 -> dev
- close #95

## Key Changes
<!-- 최대한 자세히 -->
아바타 보유 여부를 boolean 변수(hasAvatar)를 통해,
JSON 내 별도의 property를 두어 정보를 제공해줌으로 해결했습니다.