### PR TITLE
[DOCS] Swagger를 통한 API 문서 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wss/websoso/avatar/AvatarController.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarController.java
@@ -5,6 +5,7 @@ import com.wss.websoso.avatar.dto.UserRepAvatarGetResponse;
 import com.wss.websoso.avatar.dto.UserRepAvatarUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+@SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "아바타 API", description = "아바타 관련 API")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/wss/websoso/avatar/AvatarController.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarController.java
@@ -3,6 +3,9 @@ package com.wss.websoso.avatar;
 import com.wss.websoso.avatar.dto.AvatarGetResponse;
 import com.wss.websoso.avatar.dto.UserRepAvatarGetResponse;
 import com.wss.websoso.avatar.dto.UserRepAvatarUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+@Tag(name = "아바타 API", description = "아바타 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class AvatarController {
 
     private final AvatarService avatarService;
 
+    @Operation(summary = "대표 아바타 조회", description = "유저의 대표 아바타 정보를 조회한다.")
     @GetMapping("/rep-avatar")
     public ResponseEntity<UserRepAvatarGetResponse> getRepAvatar(Principal principal) {
         Long userId = Long.valueOf(principal.getName());
@@ -28,6 +33,8 @@ public class AvatarController {
                 .body(avatarService.getRepAvatar(userId));
     }
 
+    @Operation(summary = "대표 캐릭터 변경", description = "유저의 대표 아바타를 변경한다.")
+    @Parameter(name = "userRepAvatarUpdateRequest", description = "변경할 대표 아바타 ID", required = true)
     @PatchMapping("/rep-avatar")
     public ResponseEntity<Void> updateUserRepAvatar(@RequestBody UserRepAvatarUpdateRequest userRepAvatarUpdateRequest,
                                                     Principal principal) {
@@ -39,6 +46,8 @@ public class AvatarController {
                 .build();
     }
 
+    @Operation(summary = "아바타 단건 정보 조회", description = "아바타 단건 정보를 조회한다.")
+    @Parameter(name = "avatarId", description = "조회할 아바타 ID", required = true)
     @GetMapping("/avatars/{avatarId}")
     public ResponseEntity<AvatarGetResponse> getAvatar(@PathVariable Long avatarId, Principal principal) {
         Long userId = Long.valueOf(principal.getName());

--- a/src/main/java/com/wss/websoso/config/SecurityConfig.java
+++ b/src/main/java/com/wss/websoso/config/SecurityConfig.java
@@ -20,52 +20,52 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 @EnableWebSecurity //web Security를 사용할 수 있게
 public class SecurityConfig {
-      private final JwtAuthenticationFilter jwtAuthenticationFilter;
-      private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
-      private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-      @Bean
-      SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
             /*
             http의 특정 보안 구성을 비활성화하고, 인증 인가에 대한 예외를 처리
              */
-            http.csrf(AbstractHttpConfigurer::disable) // csrf 공격을 대비하기 위한 csrf 토큰 disable 하기
-                    .formLogin(AbstractHttpConfigurer::disable) // form login 비활성화 jwt를 사용하고 있으므로 폼 기반 로그인은 필요하지 않다.
-                    .httpBasic(AbstractHttpConfigurer::disable)// http 기본 인증은 사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안적으로 취약, 기본 인증을 비활성화 하고 있음
-                    .sessionManagement(session -> {
-                          session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-                    }) // session은 사용하지 않으므로 세션 관리를 STATELESS로 설정
-                    .exceptionHandling(exception ->
-                    {
-                          exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint); // 인증 에러
-                          exception.accessDeniedHandler(customAccessDeniedHandler); // 인가 에러
-                    });
+        http.csrf(AbstractHttpConfigurer::disable) // csrf 공격을 대비하기 위한 csrf 토큰 disable 하기
+                .formLogin(AbstractHttpConfigurer::disable) // form login 비활성화 jwt를 사용하고 있으므로 폼 기반 로그인은 필요하지 않다.
+                .httpBasic(AbstractHttpConfigurer::disable)// http 기본 인증은 사용자 이름과 비밀번호를 평문으로 전송하기 때문에 보안적으로 취약, 기본 인증을 비활성화 하고 있음
+                .sessionManagement(session -> {
+                    session.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                }) // session은 사용하지 않으므로 세션 관리를 STATELESS로 설정
+                .exceptionHandling(exception ->
+                {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint); // 인증 에러
+                    exception.accessDeniedHandler(customAccessDeniedHandler); // 인가 에러
+                });
 
             /*
             UsernamePasswordAuthentication 클래스 앞에 jwtAuthenticationFilter를 등록
             로그인 API 요청은 인증 인가 없이도 요청이 가능하도록 설정
              */
-            http.authorizeHttpRequests(auth -> {
-                          auth.requestMatchers("/users/login/**").permitAll();
-                          auth.anyRequest().authenticated();
-                    })
-                    .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers("/users/login/**", "/swagger-ui/**", "/api-docs/**").permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-            return http.build();
-      }
+        return http.build();
+    }
 
-      // cors에러를 대응하기 위한 메소드
-      @Bean
-      public WebMvcConfigurer corsConfigurer() {
-            return new WebMvcConfigurer() {
-                  @Override
-                  public void addCorsMappings(CorsRegistry registry) {
-                        registry.addMapping("/**")
-                                .allowedOrigins("*")
-                                .allowedOriginPatterns("*")
-                                .allowedMethods("*");
-                  }
-            };
-      }
+    // cors에러를 대응하기 위한 메소드
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("*")
+                        .allowedOriginPatterns("*")
+                        .allowedMethods("*");
+            }
+        };
+    }
 
 }

--- a/src/main/java/com/wss/websoso/config/SwaggerConfig.java
+++ b/src/main/java/com/wss/websoso/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.wss.websoso.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "웹소소 API 명세서",
+                description = "웹소소 API 명세서",
+                version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("웹소소 v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wss/websoso/config/SwaggerConfig.java
+++ b/src/main/java/com/wss/websoso/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package com.wss.websoso.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +12,13 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
         info = @Info(title = "웹소소 API 명세서",
                 description = "웹소소 API 명세서",
-                version = "v1"))
+                version = "v0.0.1"))
+@SecurityScheme(
+        name = "Bearer Authentication",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
@@ -24,5 +32,4 @@ public class SwaggerConfig {
                 .pathsToMatch(paths)
                 .build();
     }
-
 }

--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -6,6 +6,7 @@ import com.wss.websoso.memo.dto.MemosGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.security.Principal;
 import java.util.Map;
 
+@SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "메모 API", description = "메모 관련 API")
 @RestController
 @RequestMapping("/memos")

--- a/src/main/java/com/wss/websoso/memo/MemoController.java
+++ b/src/main/java/com/wss/websoso/memo/MemoController.java
@@ -3,8 +3,10 @@ package com.wss.websoso.memo;
 import com.wss.websoso.memo.dto.MemoDetailGetResponse;
 import com.wss.websoso.memo.dto.MemoUpdateRequest;
 import com.wss.websoso.memo.dto.MemosGetResponse;
-import java.security.Principal;
-import java.util.Map;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
+import java.util.Map;
+
+@Tag(name = "메모 API", description = "메모 관련 API")
 @RestController
 @RequestMapping("/memos")
 @RequiredArgsConstructor
@@ -25,6 +31,8 @@ public class MemoController {
     private final MemoService memoService;
 
     // 서재 메모 전체 조회
+    @Operation(summary = "유저 기록 전체 조회", description = "유저가 작성한 메모 전체를 조회한다.")
+    @Parameter(name = "avatarId", description = "조회할 아바타 ID", required = true)
     @GetMapping
     public MemosGetResponse getMemos(
             @RequestParam Long lastMemoId,
@@ -34,6 +42,8 @@ public class MemoController {
         return memoService.getMemos(Long.valueOf(principal.getName()), lastMemoId, size, sortType);
     }
 
+    @Operation(summary = "메모 단건 정보 조회", description = "메모 단건 정보를 조회한다.")
+    @Parameter(name = "memoId", description = "조회할 메모 ID", required = true)
     @GetMapping("/{memoId}")
     public ResponseEntity<MemoDetailGetResponse> getMemo(@PathVariable Long memoId, Principal principal) {
         Long userId = Long.valueOf(principal.getName());
@@ -43,6 +53,8 @@ public class MemoController {
     }
 
     // 삭제
+    @Operation(summary = "메모 삭제", description = "메모를 삭제한다.")
+    @Parameter(name = "memoId", description = "삭제할 메모 ID", required = true)
     @DeleteMapping("/{memoId}")
     public ResponseEntity deleteMemo(@PathVariable Long memoId, Principal principal) {
         try {
@@ -60,6 +72,11 @@ public class MemoController {
     }
 
     // 수정
+    @Operation(summary = "메모 정보 수정", description = "메모의 정보를 수정한다.")
+    @Parameters({
+            @Parameter(name = "memoId", description = "수정할 메모 ID", required = true),
+            @Parameter(name = "request", description = "변경할 메모 내용", required = true)
+    })
     @PatchMapping("/{memoId}")
     public ResponseEntity<Map<String, String>> editMemo(
             @PathVariable Long memoId,

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -2,6 +2,10 @@ package com.wss.websoso.novel;
 
 import com.wss.websoso.novel.dto.NovelDetailGetResponse;
 import com.wss.websoso.novel.dto.NovelsGetResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+@Tag(name = "작품 API", description = "작품 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/novels")
@@ -24,6 +29,12 @@ public class NovelController {
     word(검색어)를 포함하는 소설들을 lastNovelId(마지막 소설 id)를 기준으로 size(개수)만큼 가져온다.
     word에 해당하는 소설이 없으면 빈 리스트를 반환한다.
      */
+    @Operation(summary = "검색어로 작품 조회", description = "검색어가 포함된 작품 목록을 조회한다. (공백은 무시)")
+    @Parameters({
+            @Parameter(name = "lastNovelId", description = "마지막 작품 ID (첫 호출 시 9999)", required = true),
+            @Parameter(name = "size", description = "한 번 호출로 작품 개수", required = true),
+            @Parameter(name = "word", description = "검색어", required = true)
+    })
     @GetMapping
     public ResponseEntity<NovelsGetResponse> getNovelsByWord(
             @RequestParam Long lastNovelId,
@@ -32,6 +43,8 @@ public class NovelController {
         return ResponseEntity.ok().body(novelService.getNovelsByWord(lastNovelId, size, word));
     }
 
+    @Operation(summary = "작품 단건 조회", description = "작품 단건 정보를 조회한다. (해당 작품이 이미 서재에 등록되어 있다면 서재 작품을 조회)")
+    @Parameter(name = "novelId", description = "조회할 작품 ID", required = true)
     @GetMapping("/{novelId}")
     public ResponseEntity<NovelDetailGetResponse> getNovelByNovelId(@PathVariable Long novelId, Principal principal) {
         Long userId = Long.valueOf(principal.getName());

--- a/src/main/java/com/wss/websoso/novel/NovelController.java
+++ b/src/main/java/com/wss/websoso/novel/NovelController.java
@@ -5,6 +5,7 @@ import com.wss.websoso.novel.dto.NovelsGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+@SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "작품 API", description = "작품 관련 API")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/wss/websoso/user/UserController.java
+++ b/src/main/java/com/wss/websoso/user/UserController.java
@@ -3,7 +3,9 @@ package com.wss.websoso.user;
 import com.wss.websoso.user.dto.UserInfoGetResponse;
 import com.wss.websoso.user.dto.UserLoginRequest;
 import com.wss.websoso.user.dto.UserNicknameUpdateRequest;
-import java.security.Principal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
+
+@Tag(name = "유저 API", description = "유저 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -22,6 +27,8 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "로그인", description = "유저의 닉네임을 받아서 로그인 처리를 한다.")
+    @Parameter(name = "userNickname", description = "유저의 닉네임", required = true)
     @PostMapping("/login")
     public ResponseEntity<UserLoginRequest> login(@RequestParam String userNickname) {
         return ResponseEntity
@@ -29,6 +36,8 @@ public class UserController {
                 .body(userService.login(userNickname));
     }
 
+    @Operation(summary = "닉네임 변경", description = "새로운 닉네임을 받아서 유저의 닉네임을 변경한다.")
+    @Parameter(name = "userNicknameUpdateRequest", description = "유저의 새로운 닉네임", required = true)
     @PatchMapping("/nickname")
     public ResponseEntity<?> updateNickname(Principal principal,
                                             @RequestBody UserNicknameUpdateRequest userNicknameUpdateRequest) {
@@ -46,6 +55,7 @@ public class UserController {
         }
     }
 
+    @Operation(summary = "유저 정보 조회", description = "유저의 정보를 조회한다.")
     @GetMapping("/info")
     public ResponseEntity<UserInfoGetResponse> getUserInfo(Principal principal) {
         Long userId = Long.valueOf(principal.getName());

--- a/src/main/java/com/wss/websoso/user/UserController.java
+++ b/src/main/java/com/wss/websoso/user/UserController.java
@@ -5,6 +5,7 @@ import com.wss.websoso.user.dto.UserLoginRequest;
 import com.wss.websoso.user.dto.UserNicknameUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+@SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "유저 API", description = "유저 관련 API")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -9,9 +9,10 @@ import com.wss.websoso.userNovel.dto.UserNovelCreateRequest;
 import com.wss.websoso.userNovel.dto.UserNovelMemoAndInfoGetResponse;
 import com.wss.websoso.userNovel.dto.UserNovelUpdateRequest;
 import com.wss.websoso.userNovel.dto.UserNovelsResponse;
-import java.net.URI;
-import java.security.Principal;
-import java.util.Objects;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
+import java.security.Principal;
+import java.util.Objects;
+
+@Tag(name = "서재 작품 API", description = "서재 작품 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user-novels")
@@ -33,6 +39,11 @@ public class UserNovelController {
     private final UserNovelService userNovelService;
     private final MemoService memoService;
 
+    @Operation(summary = "작품 등록", description = "작품을 내 서재에 등록한다.")
+    @Parameters({
+            @Parameter(name = "novelId", description = "등록할 작품 ID", required = true),
+            @Parameter(name = "userNovelCreateRequest", description = "서재에 등록할 정보", required = true)
+    })
     @PostMapping("/{novelId}")
     public ResponseEntity<Void> createUserNovel(
             @PathVariable Long novelId,
@@ -47,6 +58,11 @@ public class UserNovelController {
         return ResponseEntity.created(location).build();
     }
 
+    @Operation(summary = "메모 생성", description = "서재 작품에 메모를 생성한다.")
+    @Parameters({
+            @Parameter(name = "userNovelId", description = "서재 작품 ID", required = true),
+            @Parameter(name = "memoCreateRequest", description = "생성할 메모 내용", required = true)
+    })
     @PostMapping("/{userNovelId}/memo")
     public ResponseEntity<MemoCreateResponse> createMemo(
             @PathVariable Long userNovelId,
@@ -60,14 +76,21 @@ public class UserNovelController {
                 .body(memoCreateResponse);
     }
 
-
+    @Operation(summary = "서재 작품 조회", description = "서재 작품 전체를 조회한다.")
+    @Parameters({
+            @Parameter(name = "readStatus", description = "읽은 상태", required = true),
+            @Parameter(name = "lastUserNovelId", description = "마지막 서재 작품 ID (최신순:9999, 오래된순:0)", required = true),
+            @Parameter(name = "size", description = "한 번 호출로 서재 작품 개수", required = true),
+            @Parameter(name = "sortType", description = "NEWEST(최신순) | OLDEST(오래된순)", required = true)
+    })
     @GetMapping
     public ResponseEntity<UserNovelsResponse> getUserNovels(
             @RequestParam String readStatus,
             @RequestParam Long lastUserNovelId,
             @RequestParam int size,
             @RequestParam String sortType,
-            Principal principal) {
+            Principal principal
+    ) {
 
         Long userId = Long.valueOf(principal.getName());
 
@@ -83,6 +106,8 @@ public class UserNovelController {
         }
     }
 
+    @Operation(summary = "서재 작품 메모&정보 조회", description = "서재 작품의 메모와 정보를 조회한다.")
+    @Parameter(name = "userNovelId", description = "조회할 서재 작품 ID", required = true)
     @GetMapping("/{userNovelId}")
     public ResponseEntity<UserNovelMemoAndInfoGetResponse> getUserNovelMemoAndInfo(@PathVariable Long userNovelId,
                                                                                    Principal principal) {
@@ -93,6 +118,7 @@ public class UserNovelController {
                 .body(userNovelService.getUserNovelMemoAndInfo(userId, userNovelId));
     }
 
+    @Operation(summary = "소소's pick 조회", description = "유저가 등록한 작품의 정보를 최신순으로 10개 조회한다. (중복X)")
     @GetMapping("/soso-picks")
     public ResponseEntity<SosoPicksGetResponse> getSosoPicks() {
         return ResponseEntity
@@ -100,6 +126,8 @@ public class UserNovelController {
                 .body(userNovelService.getSosoPicks());
     }
 
+    @Operation(summary = "서재 작품 삭제", description = "서재 작품을 삭제한다.")
+    @Parameter(name = "userNovelId", description = "삭제할 서재 작품 ID", required = true)
     @DeleteMapping("/{userNovelId}")
     public ResponseEntity<Void> deleteUserNovel(@PathVariable Long userNovelId,
                                                 Principal principal) {
@@ -112,6 +140,11 @@ public class UserNovelController {
                 .build();
     }
 
+    @Operation(summary = "서재 작품 정보 변경", description = "서재 작품의 정보를 변경한다.")
+    @Parameters({
+            @Parameter(name = "userNovelId", description = "삭제할 서재 작품 ID", required = true),
+            @Parameter(name = "userNovelUpdateRequest", description = "변경할 서재 작품 정보", required = true)
+    })
     @PatchMapping("/{userNovelId}")
     public ResponseEntity<Void> updateUserNovel(@PathVariable Long userNovelId,
                                                 @RequestBody UserNovelUpdateRequest userNovelUpdateRequest,

--- a/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelController.java
@@ -12,6 +12,7 @@ import com.wss.websoso.userNovel.dto.UserNovelsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ import java.net.URI;
 import java.security.Principal;
 import java.util.Objects;
 
+@SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "서재 작품 API", description = "서재 작품 관련 API")
 @RestController
 @RequiredArgsConstructor


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#89 -> dev
- close #89

## Key Changes
<!-- 최대한 자세히 -->
Swagger를 통한 API 문서 자동화를 했습니다.
각 API마다 이름과 설명을 명시해주었고, 모든 API에서 jwt 토큰을 사용할 수 있게 Swagger config에 @SecurityScheme 어노테이션을 설정해주었습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X