### PR TITLE
[FIX] 메모 생성 API 날짜 데이터 저장 형식 수정

### DIFF
--- a/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
+++ b/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Getter
 @MappedSuperclass
@@ -20,6 +22,7 @@ public abstract class BaseTimeEntity {
 
     @PrePersist
     public void onPrePersist() {
-        this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm"));
+        this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm")
+                .withLocale(Locale.forLanguageTag("ko")));
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#102 -> dev
- close #102

## Key Changes
<!-- 최대한 자세히 -->
메모 생성시 날짜(오전/오후)를 한국어로 저장하도록 `BaseTimeEntity` 클래스에 데이터 저장 형식을 명시해주었습니다.
```java
LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm")
                .withLocale(Locale.forLanguageTag("ko")));
``` 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X