### PR TITLE
[FIX] 서재 작품 등록 API 중복 등록 예외 처리

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovelService.java
@@ -49,6 +49,10 @@ public class UserNovelService {
         Novel novel = novelRepository.findById(novelId)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 작품이 없습니다."));
 
+        if (userNovelRepository.findByUserAndNovelId(user, novelId).isPresent()) {
+            throw new RuntimeException("이미 등록되어 있는 작품입니다.");
+        }
+
         UserNovel userNovel = UserNovel.builder()
                 .novelId(novelId)
                 .userNovelTitle(novel.getNovelTitle())


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#104 -> dev
- close #104

## Key Changes
<!-- 최대한 자세히 -->
서비스 흐름 상 한 유저가 같은 작품을 여러번 등록할 수 없도록 동작하지만, 서버 단에서 중복 등록에 대한 예외처리를 한 번 더 해줌으로써 보다 안전한 API를 만들었습니다. 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X