### PR TITLE
[FIX] 서재 작품 메모&정보 조회 API 반환값 추가

### DIFF
--- a/src/main/java/com/wss/websoso/userNovel/dto/UserNovelMemoAndInfoGetResponse.java
+++ b/src/main/java/com/wss/websoso/userNovel/dto/UserNovelMemoAndInfoGetResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public record UserNovelMemoAndInfoGetResponse(
         List<UserNovelMemosGetResponse> memos,
+        Long novelId,
         float userNovelRating,
         String userNovelTitle,
         String userNovelImg,
@@ -40,6 +41,7 @@ public record UserNovelMemoAndInfoGetResponse(
 
         return new UserNovelMemoAndInfoGetResponse(
                 memoList,
+                userNovel.getNovelId(),
                 userNovel.getUserNovelRating(),
                 userNovel.getUserNovelTitle(),
                 userNovel.getUserNovelImg(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#108 -> dev
- close #108

## Key Changes
<!-- 최대한 자세히 -->
클라이언트 요청에 의해 서재 작품 메모&정보 조회 API 반환값에 해당 서재 작품의 출처가 되는 novelId를 추가했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X