### PR TITLE
[FIX] 메모 생성 API 호출 시 생성 시간 저장 형식 변경

### DIFF
--- a/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
+++ b/src/main/java/com/wss/websoso/config/BaseTimeEntity.java
@@ -22,7 +22,7 @@ public abstract class BaseTimeEntity {
 
     @PrePersist
     public void onPrePersist() {
-        this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a HH:mm")
+        this.createdDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd a hh:mm")
                 .withLocale(Locale.forLanguageTag("ko")));
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#110 -> dev
- close #110

## Key Changes
<!-- 최대한 자세히 -->
메모 생성 API 호출 시 생성 시간 저장을 오후 20시, 오후 23시 이렇게 저장되었던 것을 오후 8시, 오후 11시로 저장되도록 저장 형식을 변경했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X