### PR TITLE
[FIX] 아바타 정보 조회 API 반환값 수정

### DIFF
--- a/src/main/java/com/wss/websoso/avatar/AvatarService.java
+++ b/src/main/java/com/wss/websoso/avatar/AvatarService.java
@@ -8,11 +8,12 @@ import com.wss.websoso.user.User;
 import com.wss.websoso.user.UserRepository;
 import com.wss.websoso.userAvatar.UserAvatar;
 import com.wss.websoso.userAvatar.UserAvatarRepository;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -70,10 +71,9 @@ public class AvatarService {
         Optional<UserAvatar> userAvatar = userAvatarRepository.findByUserAndAvatar(user, avatar);
 
         if (userAvatar.isEmpty()) {
-            return AvatarGetResponse.of(avatar, avatar.getAvatarUnacquiredMent(),
-                    avatar.getAvatarUnacquiredCondition());
+            return AvatarGetResponse.of(avatar, false);
         }
 
-        return AvatarGetResponse.of(avatar, avatar.getAvatarAcquiredMent(), avatar.getAvatarAcquiredCondition());
+        return AvatarGetResponse.of(avatar, true);
     }
 }

--- a/src/main/java/com/wss/websoso/avatar/dto/AvatarGetResponse.java
+++ b/src/main/java/com/wss/websoso/avatar/dto/AvatarGetResponse.java
@@ -1,19 +1,27 @@
 package com.wss.websoso.avatar.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wss.websoso.avatar.Avatar;
 
 public record AvatarGetResponse(
+        Long avatarId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String avatarImg,
         String avatarTag,
         String avatarGenreBadgeImg,
         String avatarMent,
-        String avatarCondition
+        String avatarCondition,
+        boolean hasAvatar
 ) {
-    public static AvatarGetResponse of(Avatar avatar, String avatarMent, String avatarCondition) {
+    public static AvatarGetResponse of(Avatar avatar, boolean hasAvatar) {
         return new AvatarGetResponse(
+                avatar.getAvatarId(),
+                hasAvatar ? null : avatar.getAvatarUnacquiredImg(),
                 avatar.getAvatarTag(),
                 avatar.getAvatarGenreBadgeImg(),
-                avatarMent,
-                avatarCondition
+                hasAvatar ? avatar.getAvatarAcquiredMent() : avatar.getAvatarUnacquiredMent(),
+                hasAvatar ? avatar.getAvatarAcquiredCondition() : avatar.getAvatarUnacquiredCondition(),
+                hasAvatar
         );
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#105 -> dev
- close #105

## Key Changes
<!-- 최대한 자세히 -->
클라이언트 요청에 따라 아바타 정보 조회 API 반환값에 보유 아바타 여부, 아바타 ID, 미보유 아바타 조회 시 아바타 이미지를 추가했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X