### PR TITLE
[FIX] 아바타 정보(단건) 조회 API 반환값 수정

### DIFF
--- a/src/main/java/com/wss/websoso/avatar/dto/AvatarGetResponse.java
+++ b/src/main/java/com/wss/websoso/avatar/dto/AvatarGetResponse.java
@@ -1,11 +1,9 @@
 package com.wss.websoso.avatar.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wss.websoso.avatar.Avatar;
 
 public record AvatarGetResponse(
         Long avatarId,
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         String avatarImg,
         String avatarTag,
         String avatarGenreBadgeImg,
@@ -16,7 +14,7 @@ public record AvatarGetResponse(
     public static AvatarGetResponse of(Avatar avatar, boolean hasAvatar) {
         return new AvatarGetResponse(
                 avatar.getAvatarId(),
-                hasAvatar ? null : avatar.getAvatarUnacquiredImg(),
+                hasAvatar ? "" : avatar.getAvatarUnacquiredImg(),
                 avatar.getAvatarTag(),
                 avatar.getAvatarGenreBadgeImg(),
                 hasAvatar ? avatar.getAvatarAcquiredMent() : avatar.getAvatarUnacquiredMent(),


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#118 -> dev
- close #118

## Key Changes
<!-- 최대한 자세히 -->
클라이언트 요청에 따라 아바타 정보(단건) 조회 API의 반환값에 보유한 이미지더라도 avatarImg를 빈 문자열 값으로 반환하도록 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X