### PR TITLE
[FIX] 닉네임 수정 시 앞뒤 공백 제거하여 저장

### DIFF
--- a/src/main/java/com/wss/websoso/novel/Novel.java
+++ b/src/main/java/com/wss/websoso/novel/Novel.java
@@ -36,7 +36,7 @@ public class Novel {
     @Column(name = "novel_genre", nullable = false)
     private String novelGenre;
 
-    @Column(name = "novel_img", nullable = false)
+    @Column(name = "novel_img", columnDefinition = "text", nullable = false)
     private String novelImg;
 
     @Column(name = "novel_description", columnDefinition = "text", nullable = false)

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
             throw new IllegalArgumentException("닉네임이 없습니다.");
         }
 
-        user.updateUserNickname(newUserNickname);
+        user.updateUserNickname(newUserNickname.strip());
     }
 
     public UserInfoGetResponse getUserInfo(Long userId) {

--- a/src/main/java/com/wss/websoso/user/dto/UserInfoGetResponse.java
+++ b/src/main/java/com/wss/websoso/user/dto/UserInfoGetResponse.java
@@ -12,7 +12,7 @@ public record UserInfoGetResponse(
         String representativeAvatarTag,
         String representativeAvatarLineContent,
         String representativeAvatarImg,
-        String userNickName,
+        String userNickname,
         long userNovelCount,
         long memoCount,
         List<UserAvatarsGetResponse> userAvatars

--- a/src/main/java/com/wss/websoso/userNovel/UserNovel.java
+++ b/src/main/java/com/wss/websoso/userNovel/UserNovel.java
@@ -48,7 +48,7 @@ public class UserNovel {
     @Column(name = "user_novel_genre", nullable = false)
     private String userNovelGenre;
 
-    @Column(name = "user_novel_img", nullable = false)
+    @Column(name = "user_novel_img", columnDefinition = "text", nullable = false)
     private String userNovelImg;
 
     @Column(name = "user_novel_description", columnDefinition = "text", nullable = false)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#114 -> dev
- close #114

## Key Changes
<!-- 최대한 자세히 -->
- 유저 닉네임 변경 API에서 닉네임의 앞뒤에 공백이 들어가는 경우 제거하여 저장합니다.
- 유저 정보 조회 API의 UserInfoGetResponse에서 userNickname이 userNickName으로 되어 있어 수정했습니다.
- 이미지의 url 데이터 타입 varchar(255) -> text로 변경했습니다.