### PR TITLE
[FIX] 로그인 API RequestParam 수정

### DIFF
--- a/src/main/java/com/wss/websoso/user/UserController.java
+++ b/src/main/java/com/wss/websoso/user/UserController.java
@@ -32,10 +32,10 @@ public class UserController {
     @Operation(summary = "로그인", description = "유저의 닉네임을 받아서 로그인 처리를 한다.")
     @Parameter(name = "userNickname", description = "유저의 닉네임", required = true)
     @PostMapping("/login")
-    public ResponseEntity<UserLoginRequest> login(@RequestParam String userNickname) {
+    public ResponseEntity<UserLoginRequest> login(@RequestParam Long userId) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(userService.login(userNickname));
+                .body(userService.login(userId));
     }
 
     @Operation(summary = "닉네임 변경", description = "새로운 닉네임을 받아서 유저의 닉네임을 변경한다.")

--- a/src/main/java/com/wss/websoso/user/UserService.java
+++ b/src/main/java/com/wss/websoso/user/UserService.java
@@ -11,12 +11,13 @@ import com.wss.websoso.user.dto.UserLoginRequest;
 import com.wss.websoso.userAvatar.UserAvatarRepository;
 import com.wss.websoso.userNovel.UserNovelRepository;
 import com.wss.websoso.userNovel.dto.UserAvatarsGetResponse;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +32,8 @@ public class UserService {
     private final AvatarLineRepository avatarLineRepository;
     private final UserAvatarRepository userAvatarRepository;
 
-    public UserLoginRequest login(String userNickname) {
-        User user = userRepository.findByUserNickname(userNickname)
+    public UserLoginRequest login(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("해당하는 사용자가 없습니다."));
 
         UserAuthentication userAuthentication = new UserAuthentication(user.getUserId(), null, null);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#123 -> dev
- close #123

## Key Changes
<!-- 최대한 자세히 -->
클라이언트 요청에 따라 기존 유저의 닉네임을 받아 토큰을 발급하던 기존 로그인 API에서 유저의 고유 ID값을 받아 토큰을 발급하도록 RequestParam을 수정했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X